### PR TITLE
Fix #481: OWML stops the options menu's tooltips from appearing

### DIFF
--- a/src/OWML.ModHelper.Menus/ModsMenu.cs
+++ b/src/OWML.ModHelper.Menus/ModsMenu.cs
@@ -175,7 +175,6 @@ namespace OWML.ModHelper.Menus
 			modsTab.BaseButtons.ForEach(x => x.Hide());
 			modsTab.Menu.GetComponentsInChildren<SliderElement>(true).ToList().ForEach(x => x.gameObject.SetActive(false));
 			modsTab.Menu.GetComponentsInChildren<OptionsSelectorElement>(true).ToList().ForEach(x => x.gameObject.transform.localScale = Vector3.zero);
-			modsTab.Menu.GetValue<TooltipDisplay>("_tooltipDisplay").GetComponent<Text>().color = Color.clear;
 			modsTab.Menu.gameObject.name = name;
 			modsTab.TabButton.gameObject.name = name + "_tab";
 			options.AddTab(modsTab, enable);


### PR DESCRIPTION
For some reason, when OWML creates the Mods tab menu, it sets the color of the tooltip to clear (completely transparent), making it invisible (#481) (the same tooltip is used for all options menus). Removing the line that does that makes the tooltip display again.

Before:
![before](https://user-images.githubusercontent.com/22490080/194778568-614af2aa-3893-43ce-a474-8fab7e98269b.png)

After:
![after](https://user-images.githubusercontent.com/22490080/194778610-d7700e24-eedc-4d12-a264-0a15e621ba96.png)
