### PR TITLE
Add tooltips to mod settings

### DIFF
--- a/src/OWML.ModHelper.Menus/ModConfigMenuBase.cs
+++ b/src/OWML.ModHelper.Menus/ModConfigMenuBase.cs
@@ -81,22 +81,22 @@ namespace OWML.ModHelper.Menus
 				switch (settingType)
 				{
 					case "separator":
-						AddSeparator(key, obj, index);
+						AddSeparator(key, index, obj);
 						return;
 					case "slider":
-						AddSliderInput(key, obj, index);
+						AddSliderInput(key, index, obj);
 						return;
 					case "toggle":
-						AddToggleInput(key, obj, index);
+						AddToggleInput(key, index, obj);
 						return;
 					case "selector":
-						AddSelectorInput(key, obj, index);
+						AddSelectorInput(key, index, obj);
 						return;
 					case "text":
-						AddTextInput(key, obj, index);
+						AddTextInput(key, index, obj);
 						return;
 					case "number":
-						AddNumberInput(key, obj, index);
+						AddNumberInput(key, index, obj);
 						return;
 					default:
 						Console.WriteLine("Unrecognized complex setting type: " + settingType, MessageType.Warning);
@@ -107,23 +107,15 @@ namespace OWML.ModHelper.Menus
 			Console.WriteLine("Unrecognized setting type: " + value.GetType(), MessageType.Error);
 		}
 
-		private void AddToggleInput(string key, int index)
+		private void AddToggleInput(string key, int index, JObject obj = null)
 		{
 			var toggle = AddToggleInput(_toggleTemplate.Copy(key), index);
 			toggle.Element.name = key;
-			toggle.Title = key;
+			toggle.Title = (string)obj?["title"] ?? key;
 			toggle.Show();
 		}
 
-		private void AddToggleInput(string key, JObject obj, int index)
-		{
-			var toggle = AddToggleInput(_toggleTemplate.Copy(key), index);
-			toggle.Element.name = key;
-			toggle.Title = (string)obj["title"] ?? key;
-			toggle.Show();
-		}
-
-		private void AddSliderInput(string key, JObject obj, int index)
+		private void AddSliderInput(string key, int index, JObject obj)
 		{
 			var slider = AddSliderInput(_sliderTemplate.Copy(key), index);
 			slider.Min = (float)obj["min"];
@@ -133,7 +125,7 @@ namespace OWML.ModHelper.Menus
 			slider.Show();
 		}
 
-		private void AddSelectorInput(string key, JObject obj, int index)
+		private void AddSelectorInput(string key, int index, JObject obj)
 		{
 			var options = obj["options"].ToObject<string[]>();
 			var selector = AddSelectorInput(_selectorTemplate.Copy(key), index);
@@ -143,43 +135,27 @@ namespace OWML.ModHelper.Menus
 			selector.Show();
 		}
 
-		private void AddTextInput(string key, JObject obj, int index)
+		private void AddTextInput(string key, int index, JObject obj = null)
 		{
 			var textInput = AddTextInput(_textInputTemplate.Copy(key), index);
 			textInput.Element.name = key;
-			textInput.Title = (string)obj["title"] ?? key;
+			textInput.Title = (string)obj?["title"] ?? key;
 			textInput.Show();
 		}
 
-		private void AddTextInput(string key, int index)
-		{
-			var textInput = AddTextInput(_textInputTemplate.Copy(key), index);
-			textInput.Element.name = key;
-			textInput.Title = key;
-			textInput.Show();
-		}
-
-		private void AddNumberInput(string key, JObject obj, int index)
+		private void AddNumberInput(string key, int index, JObject obj = null)
 		{
 			var numberInput = AddNumberInput(_numberInputTemplate.Copy(key), index);
 			numberInput.Element.name = key;
-			numberInput.Title = (string)obj["title"] ?? key;
+			numberInput.Title = (string)obj?["title"] ?? key;
 			numberInput.Show();
 		}
 
-		private void AddNumberInput(string key, int index)
-		{
-			var numberInput = AddNumberInput(_numberInputTemplate.Copy(key), index);
-			numberInput.Element.name = key;
-			numberInput.Title = key;
-			numberInput.Show();
-		}
-
-		private void AddSeparator(string key, JObject obj, int index)
+		private void AddSeparator(string key, int index, JObject obj)
 		{
 			var numberInput = AddSeparator(_seperatorTemplate.Copy("Inputs"), index);
 			numberInput.Element.name = key;
-			numberInput.Title = (string)obj["title"] ?? key;
+			numberInput.Title = (string)obj?["title"] ?? key;
 			numberInput.Show();
 		}
 	}

--- a/src/OWML.ModHelper.Menus/ModConfigMenuBase.cs
+++ b/src/OWML.ModHelper.Menus/ModConfigMenuBase.cs
@@ -112,6 +112,7 @@ namespace OWML.ModHelper.Menus
 			var toggle = AddToggleInput(_toggleTemplate.Copy(key), index);
 			toggle.Element.name = key;
 			toggle.Title = (string)obj?["title"] ?? key;
+			SetupInputTooltip(toggle);
 			toggle.Show();
 		}
 
@@ -122,6 +123,7 @@ namespace OWML.ModHelper.Menus
 			slider.Max = (float)obj["max"];
 			slider.Element.name = key;
 			slider.Title = (string)obj["title"] ?? key;
+			SetupInputTooltip(slider);
 			slider.Show();
 		}
 
@@ -132,6 +134,7 @@ namespace OWML.ModHelper.Menus
 			selector.Element.name = key;
 			selector.Title = (string)obj["title"] ?? key;
 			selector.Initialize((string)obj["value"], options);
+			SetupInputTooltip(selector);
 			selector.Show();
 		}
 
@@ -140,6 +143,7 @@ namespace OWML.ModHelper.Menus
 			var textInput = AddTextInput(_textInputTemplate.Copy(key), index);
 			textInput.Element.name = key;
 			textInput.Title = (string)obj?["title"] ?? key;
+			SetupInputTooltip(textInput);
 			textInput.Show();
 		}
 
@@ -148,6 +152,7 @@ namespace OWML.ModHelper.Menus
 			var numberInput = AddNumberInput(_numberInputTemplate.Copy(key), index);
 			numberInput.Element.name = key;
 			numberInput.Title = (string)obj?["title"] ?? key;
+			SetupInputTooltip(numberInput);
 			numberInput.Show();
 		}
 
@@ -157,6 +162,13 @@ namespace OWML.ModHelper.Menus
 			numberInput.Element.name = key;
 			numberInput.Title = (string)obj?["title"] ?? key;
 			numberInput.Show();
+		}
+
+		private void SetupInputTooltip<T>(IModInput<T> input)
+		{
+			var menuOption = input.Element.GetComponent<MenuOption>();
+			menuOption.SetValue("_tooltipTextType", UITextType.None);
+			menuOption.SetValue("_overrideTooltipText", "");
 		}
 	}
 }

--- a/src/OWML.ModHelper.Menus/ModConfigMenuBase.cs
+++ b/src/OWML.ModHelper.Menus/ModConfigMenuBase.cs
@@ -112,7 +112,7 @@ namespace OWML.ModHelper.Menus
 			var toggle = AddToggleInput(_toggleTemplate.Copy(key), index);
 			toggle.Element.name = key;
 			toggle.Title = (string)obj?["title"] ?? key;
-			SetupInputTooltip(toggle);
+			SetupInputTooltip(toggle, (string)obj?["tooltip"]);
 			toggle.Show();
 		}
 
@@ -123,7 +123,7 @@ namespace OWML.ModHelper.Menus
 			slider.Max = (float)obj["max"];
 			slider.Element.name = key;
 			slider.Title = (string)obj["title"] ?? key;
-			SetupInputTooltip(slider);
+			SetupInputTooltip(slider, (string)obj["tooltip"]);
 			slider.Show();
 		}
 
@@ -134,7 +134,7 @@ namespace OWML.ModHelper.Menus
 			selector.Element.name = key;
 			selector.Title = (string)obj["title"] ?? key;
 			selector.Initialize((string)obj["value"], options);
-			SetupInputTooltip(selector);
+			SetupInputTooltip(selector, (string)obj["tooltip"]);
 			selector.Show();
 		}
 
@@ -143,7 +143,7 @@ namespace OWML.ModHelper.Menus
 			var textInput = AddTextInput(_textInputTemplate.Copy(key), index);
 			textInput.Element.name = key;
 			textInput.Title = (string)obj?["title"] ?? key;
-			SetupInputTooltip(textInput);
+			SetupInputTooltip(textInput, (string)obj?["tooltip"]);
 			textInput.Show();
 		}
 
@@ -152,23 +152,23 @@ namespace OWML.ModHelper.Menus
 			var numberInput = AddNumberInput(_numberInputTemplate.Copy(key), index);
 			numberInput.Element.name = key;
 			numberInput.Title = (string)obj?["title"] ?? key;
-			SetupInputTooltip(numberInput);
+			SetupInputTooltip(numberInput, (string)obj?["tooltip"]);
 			numberInput.Show();
 		}
 
 		private void AddSeparator(string key, int index, JObject obj)
 		{
-			var numberInput = AddSeparator(_seperatorTemplate.Copy("Inputs"), index);
-			numberInput.Element.name = key;
-			numberInput.Title = (string)obj?["title"] ?? key;
-			numberInput.Show();
+			var separator = AddSeparator(_seperatorTemplate.Copy("Inputs"), index);
+			separator.Element.name = key;
+			separator.Title = (string)obj?["title"] ?? key;
+			separator.Show();
 		}
 
-		private void SetupInputTooltip<T>(IModInput<T> input)
+		private void SetupInputTooltip<T>(IModInput<T> input, string tooltip)
 		{
 			var menuOption = input.Element.GetComponent<MenuOption>();
 			menuOption.SetValue("_tooltipTextType", UITextType.None);
-			menuOption.SetValue("_overrideTooltipText", "");
+			menuOption.SetValue("_overrideTooltipText", tooltip?? "");
 		}
 	}
 }

--- a/src/SampleMods/OWML.LoadCustomAssets/LoadCustomAssets.cs
+++ b/src/SampleMods/OWML.LoadCustomAssets/LoadCustomAssets.cs
@@ -54,7 +54,7 @@ namespace OWML.LoadCustomAssets
 
 		private void TestAPI()
 		{
-			var api = ModHelper.Interaction.GetModApi<IAPI>("_nebula.ExampleAPI");
+			var api = ModHelper.Interaction.TryGetModApi<IAPI>("_nebula.ExampleAPI");
 			ModHelper.Console.WriteLine(api.Echo("Test API echo!"));
 			ModHelper.Console.WriteLine("Test API radio: " + api.Radio<ABC>().ToString());
 		}

--- a/src/SampleMods/OWML.LoadCustomAssets/default-config.json
+++ b/src/SampleMods/OWML.LoadCustomAssets/default-config.json
@@ -7,7 +7,8 @@
 			"value": true,
 			"yes": "Quack",
 			"no": "Queck",
-			"title": "Enable Ducks"
+			"title": "Enable Ducks",
+			"tooltip": "Quack!"
 		},
 		"enableCubes": false,
 		"alphabet": "abc",
@@ -16,7 +17,8 @@
 			"type": "slider",
 			"value": 10,
 			"min": 0,
-			"max": 20
+			"max": 20,
+			"tooltip": "POWER SLIDER"
 		},
 		"negativeMin": {
 			"type": "slider",
@@ -39,6 +41,7 @@
 		"thing": {
 			"type": "selector",
 			"options": [ "A", "B", "C" ],
+			"tooltip": "Select your favorite letter.",
 			"value": "A"
 		},
 		"integer thing": {
@@ -52,6 +55,19 @@
 			"yes": "Absolutely",
 			"no": "Na-ah!",
 			"title": "Enable Super Mode"
+		},
+		"Duck Info": {
+			"type": "separator"
+		},
+		"Duck Name": {
+			"type": "text",
+			"value": "Bonifacio",
+			"tooltip": "Note: Ernesto is already taken"
+		},
+		"Duck Age": {
+			"type": "number",
+			"value": 42,
+			"tooltip": "How old is the duck?"
 		}
 	}
 }


### PR DESCRIPTION
Adds the `tooltip` property to mod settings, allowing modders to communicate the user information about certain options.

![duck](https://user-images.githubusercontent.com/22490080/194786708-36bbda5a-8fcd-41ff-8561-3f5dd0f28c2b.jpg)

This also fixed a bug I introduced in #497 where mod settings displayed tooltips of the base game template setting inputs (except for toggle settings). Now if a setting `tooltip` isn't set then the tooltip won't show up for that setting.