### PR TITLE
Normalize Application.dataPath

### DIFF
--- a/src/OWML.Abstractions/ApplicationHelper.cs
+++ b/src/OWML.Abstractions/ApplicationHelper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using OWML.Common;
 using UnityEngine;
 
@@ -6,7 +7,7 @@ namespace OWML.Abstractions
 {
 	public class ApplicationHelper : IApplicationHelper
 	{
-		public string DataPath => Application.dataPath;
+		public string DataPath => Path.GetFullPath(Application.dataPath);
 
 		public string Version => Application.version;
 


### PR DESCRIPTION
Currently, ApplicationHelper returns Application.dataPath. However, this uses forward slashes which break on Linux inside of Wine. Calling `Path.GetFullPath` on the string will normalize it.