### PR TITLE
Only sort enabled mods by order

### DIFF
--- a/src/OWML.Launcher/OWML.Manifest.json
+++ b/src/OWML.Launcher/OWML.Manifest.json
@@ -3,7 +3,7 @@
   "author": "Alek",
   "name": "OWML",
   "uniqueName": "Alek.OWML",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "minGameVersion": "1.1.13.393",
   "maxGameVersion": "1.1.13.456"
 }

--- a/src/OWML.ModLoader/ModSorter.cs
+++ b/src/OWML.ModLoader/ModSorter.cs
@@ -13,7 +13,7 @@ namespace OWML.ModLoader
 
 		public IList<IModData> SortMods(IList<IModData> mods)
 		{
-			// When detecting a cyclic mod dependency we give up on sorting mods at all
+			// #541 When detecting a cyclic mod dependency we give up on sorting mods at all
 			// When this happens because of a disabled mod it will potentially break the rest of the mods for no reason
 			var enabledMods = mods.Where(x => x.Enabled).ToList();
 


### PR DESCRIPTION
Currently the mod loader can't support cyclic mod dependencies. This doesn't fix that. It however checks if disabled mods have cyclic dependencies even though they aren't going to be loaded. This PR has it ignore disabled mods when sorting.

Else you can have a mod with cyclic dependency, disable it, and still have your load order broken on all other mods. Was happening with outdated Outsider Translation mod.

Fixes #541