### PR TITLE
2.9.4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
         run: msbuild OWML.sln
         
       - name: pack
-        run: dotnet pack -o . src\OWML.ModHelper\OWML.ModHelper.csproj -p:NuspecFile=OWML.ModHelper.nuspec -p:NuspecBasePath=src\OWML.ModHelper -p:NuspecProperties="version=${{ steps.version.outputs.prop }};"
+        run: dotnet pack -o . src\OWML.ModHelper\OWML.ModHelper.csproj -p:NuspecFile=OWML.ModHelper.nuspec -p:NuspecProperties="version=${{ steps.version.outputs.prop }};"
       - name: upload nuget
         uses: actions/upload-artifact@v2
         with:

--- a/src/OWML.Launcher/OWML.Manifest.json
+++ b/src/OWML.Launcher/OWML.Manifest.json
@@ -3,7 +3,7 @@
   "author": "Alek",
   "name": "OWML",
   "uniqueName": "Alek.OWML",
-  "version": "2.9.5",
+  "version": "2.9.4",
   "minGameVersion": "1.1.13.393",
   "maxGameVersion": "1.1.13.456"
 }

--- a/src/OWML.Launcher/OWML.Manifest.json
+++ b/src/OWML.Launcher/OWML.Manifest.json
@@ -3,7 +3,7 @@
   "author": "Alek",
   "name": "OWML",
   "uniqueName": "Alek.OWML",
-  "version": "2.9.2",
+  "version": "2.9.3",
   "minGameVersion": "1.1.13.393",
   "maxGameVersion": "1.1.13.456"
 }

--- a/src/OWML.Launcher/OWML.Manifest.json
+++ b/src/OWML.Launcher/OWML.Manifest.json
@@ -3,7 +3,7 @@
   "author": "Alek",
   "name": "OWML",
   "uniqueName": "Alek.OWML",
-  "version": "2.9.4",
+  "version": "2.9.5",
   "minGameVersion": "1.1.13.393",
   "maxGameVersion": "1.1.13.456"
 }

--- a/src/OWML.Launcher/OWML.Manifest.json
+++ b/src/OWML.Launcher/OWML.Manifest.json
@@ -3,7 +3,7 @@
   "author": "Alek",
   "name": "OWML",
   "uniqueName": "Alek.OWML",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "minGameVersion": "1.1.13.393",
   "maxGameVersion": "1.1.13.456"
 }

--- a/src/OWML.ModHelper.Interaction/InterfaceProxyBuilder.cs
+++ b/src/OWML.ModHelper.Interaction/InterfaceProxyBuilder.cs
@@ -59,10 +59,16 @@ namespace OWML.ModHelper.Interaction
 				if (!typeA.IsGenericType)
 					return false;
 
-				if (typeA.GetGenericArguments()[0].GenericParameterPosition == typeB.GetGenericArguments()[0].GenericParameterPosition)
-					return true;
+				if (typeA.GetGenericArguments().Length != typeB.GetGenericArguments().Length)
+					return false;
 
-				return false;
+				for (var i = 0; i < typeA.GetGenericArguments().Length; i++)
+				{
+					if (typeA.GetGenericArguments()[i].GenericParameterPosition != typeB.GetGenericArguments()[i].GenericParameterPosition)
+						return false;
+				}
+
+				return true;
 			}
 
 			foreach (var proxyMethod in interfaceType.GetMethods())

--- a/src/OWML.ModHelper.Interaction/InterfaceProxyBuilder.cs
+++ b/src/OWML.ModHelper.Interaction/InterfaceProxyBuilder.cs
@@ -48,7 +48,21 @@ namespace OWML.ModHelper.Interaction
 				if (typeA.IsGenericParameter != typeB.IsGenericParameter)
 					return false;
 
-				return typeA.IsGenericParameter ? typeA.GenericParameterPosition == typeB.GenericParameterPosition : typeA.IsAssignableFrom(typeB);
+				if (typeA.IsGenericParameter)
+				{
+					return typeA.GenericParameterPosition == typeB.GenericParameterPosition;
+				}
+
+				if (typeA.IsAssignableFrom(typeB))
+					return true;
+
+				if (!typeA.IsGenericType)
+					return false;
+
+				if (typeA.GetGenericArguments()[0].GenericParameterPosition == typeB.GetGenericArguments()[0].GenericParameterPosition)
+					return true;
+
+				return false;
 			}
 
 			foreach (var proxyMethod in interfaceType.GetMethods())

--- a/src/OWML.ModHelper/OWML.ModHelper.csproj
+++ b/src/OWML.ModHelper/OWML.ModHelper.csproj
@@ -3,10 +3,10 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
 	  <LangVersion>9.0</LangVersion>
-	  <PackageVersion>2.9.2</PackageVersion>
+	  <PackageVersion>2.9.3</PackageVersion>
 	  <PackageId>OWML</PackageId>
 	  <Title>OWML</Title>
-	  <Version>2.9.2</Version>
+	  <Version>2.9.3</Version>
 	  <Authors>Alek, Nebula, Raicuparta, TAImatem</Authors>
 	  <Description>Mod loader and mod framework for Outer Wilds</Description>
 	  <PackageTags>Outer Wilds</PackageTags>

--- a/src/OWML.ModHelper/OWML.ModHelper.csproj
+++ b/src/OWML.ModHelper/OWML.ModHelper.csproj
@@ -3,10 +3,10 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
 	  <LangVersion>9.0</LangVersion>
-	  <PackageVersion>2.9.1</PackageVersion>
+	  <PackageVersion>2.9.2</PackageVersion>
 	  <PackageId>OWML</PackageId>
 	  <Title>OWML</Title>
-	  <Version>2.9.1</Version>
+	  <Version>2.9.2</Version>
 	  <Authors>Alek, Nebula, Raicuparta, TAImatem</Authors>
 	  <Description>Mod loader and mod framework for Outer Wilds</Description>
 	  <PackageTags>Outer Wilds</PackageTags>

--- a/src/OWML.ModHelper/OWML.ModHelper.nuspec
+++ b/src/OWML.ModHelper/OWML.ModHelper.nuspec
@@ -21,6 +21,7 @@
     </dependencies>
   </metadata>
   <files>
+    <file src="bin\Debug\net48\OWML.ModHelper.dll" target="lib\net48" />
     <file src="bin\Debug\net48\OWML.ModHelper.Assets.dll" target="lib\net48" />
     <file src="bin\Debug\net48\OWML.ModHelper.Events.dll" target="lib\net48" />
     <file src="bin\Debug\net48\OWML.ModHelper.Menus.dll" target="lib\net48" />


### PR DESCRIPTION
- The mod list is now pre-sorted by the unique name, so mods with the same dependents (addons) will be loaded in the same order every time.
- Mod APIs now support generic parameters.