### PR TITLE
2.9.6

### DIFF
--- a/src/OWML.Launcher/OWML.Manifest.json
+++ b/src/OWML.Launcher/OWML.Manifest.json
@@ -3,7 +3,7 @@
   "author": "Alek",
   "name": "OWML",
   "uniqueName": "Alek.OWML",
-  "version": "2.9.5",
+  "version": "2.9.6",
   "minGameVersion": "1.1.13.393",
   "maxGameVersion": "1.1.13.456"
 }

--- a/src/OWML.ModHelper.Interaction/InterfaceProxyBuilder.cs
+++ b/src/OWML.ModHelper.Interaction/InterfaceProxyBuilder.cs
@@ -180,7 +180,7 @@ namespace OWML.ModHelper.Interaction
 
 			// Equivalent code :
 
-			// return instance.method(arg1, arg2, ...);
+			// return __Target.methodname(arg1, arg2, ...);
 		}
 
 		private void CreateConstructor(TypeBuilder proxyBuilder, FieldBuilder targetField, Type targetType)
@@ -194,12 +194,13 @@ namespace OWML.ModHelper.Interaction
 			il.Emit(OpCodes.Ldarg_1);      // load argument
 			il.Emit(OpCodes.Stfld, targetField); // set field to loaded argument
 			il.Emit(OpCodes.Ret);
+
 			// Equivalent code :
 
 			/*
-			 *	public ctor(Type targetType)
+			 *	public ctor(TargetType targetType)
 			 *	{
-			 *		this.targetField = targetType;
+			 *		this.__Target = targetType;
 			 *	}
 			 */
 		}

--- a/src/OWML.ModHelper.Interaction/InterfaceProxyBuilder.cs
+++ b/src/OWML.ModHelper.Interaction/InterfaceProxyBuilder.cs
@@ -79,7 +79,8 @@ namespace OWML.ModHelper.Interaction
 				if (a.IsEnum && b.IsEnum)
 				{
 					if (Enum.GetNames(a).Length != Enum.GetNames(b).Length
-					    || a.Name != b.Name)
+					    || a.Name != b.Name
+						|| a.GetEnumUnderlyingType() != b.GetEnumUnderlyingType())
 					{
 						return false;
 					}

--- a/src/OWML.ModHelper.Interaction/InterfaceProxyBuilder.cs
+++ b/src/OWML.ModHelper.Interaction/InterfaceProxyBuilder.cs
@@ -76,6 +76,13 @@ namespace OWML.ModHelper.Interaction
 					return false;
 				}
 
+				if (a.IsEnum && b.IsEnum)
+				{
+					// this doesn't check if the actual enum values are identical.... too bad!
+					return Enum.GetNames(a).Length == Enum.GetNames(b).Length
+					       && a.Name == b.Name;
+				}
+
 				if (a.IsGenericParameter)
 				{
 					// most likely the type is T

--- a/src/OWML.ModHelper.Interaction/InterfaceProxyBuilder.cs
+++ b/src/OWML.ModHelper.Interaction/InterfaceProxyBuilder.cs
@@ -177,6 +177,10 @@ namespace OWML.ModHelper.Interaction
 
 			// return result
 			il.Emit(OpCodes.Ret);
+
+			// Equivalent code :
+
+			// return instance.method(arg1, arg2, ...);
 		}
 
 		private void CreateConstructor(TypeBuilder proxyBuilder, FieldBuilder targetField, Type targetType)
@@ -190,6 +194,14 @@ namespace OWML.ModHelper.Interaction
 			il.Emit(OpCodes.Ldarg_1);      // load argument
 			il.Emit(OpCodes.Stfld, targetField); // set field to loaded argument
 			il.Emit(OpCodes.Ret);
+			// Equivalent code :
+
+			/*
+			 *	public ctor(Type targetType)
+			 *	{
+			 *		this.targetField = targetType;
+			 *	}
+			 */
 		}
 	}
 }

--- a/src/OWML.ModHelper.Interaction/InterfaceProxyBuilder.cs
+++ b/src/OWML.ModHelper.Interaction/InterfaceProxyBuilder.cs
@@ -78,9 +78,32 @@ namespace OWML.ModHelper.Interaction
 
 				if (a.IsEnum && b.IsEnum)
 				{
-					// this doesn't check if the actual enum values are identical.... too bad!
-					return Enum.GetNames(a).Length == Enum.GetNames(b).Length
-					       && a.Name == b.Name;
+					if (Enum.GetNames(a).Length != Enum.GetNames(b).Length
+					    || a.Name != b.Name)
+					{
+						return false;
+					}
+
+					for (var i = 0; i < Enum.GetNames(a).Length; i++)
+					{
+						var nameA = Enum.GetNames(a)[i];
+						var nameB = Enum.GetNames(b)[i];
+
+						if (nameA != nameB)
+						{
+							return false;
+						}
+
+						var valueA = Convert.ChangeType(Enum.Parse(a, nameA), a.GetEnumUnderlyingType());
+						var valueB = Convert.ChangeType(Enum.Parse(b, nameB), b.GetEnumUnderlyingType());
+
+						if (!valueA.Equals(valueB))
+						{
+							return false;
+						}
+					}
+
+					return true;
 				}
 
 				if (a.IsGenericParameter)


### PR DESCRIPTION
APIs can now use custom enums. The enums need to be identical on both sides. That means the :
- Type name
- Amount of entries in the enum
- The underlying type (int, uint, ulong, etc.)
- Value of each entry

has to be the same.