### PR TITLE
2.9.7

### DIFF
--- a/src/OWML.Launcher/OWML.Manifest.json
+++ b/src/OWML.Launcher/OWML.Manifest.json
@@ -3,7 +3,7 @@
   "author": "Alek",
   "name": "OWML",
   "uniqueName": "Alek.OWML",
-  "version": "2.9.6",
+  "version": "2.9.7",
   "minGameVersion": "1.1.13.393",
   "maxGameVersion": "1.1.13.456"
 }

--- a/src/OWML.ModHelper.Interaction/InterfaceProxyBuilder.cs
+++ b/src/OWML.ModHelper.Interaction/InterfaceProxyBuilder.cs
@@ -78,33 +78,8 @@ namespace OWML.ModHelper.Interaction
 
 				if (a.IsEnum && b.IsEnum)
 				{
-					if (Enum.GetNames(a).Length != Enum.GetNames(b).Length
-					    || a.Name != b.Name
-						|| a.GetEnumUnderlyingType() != b.GetEnumUnderlyingType())
-					{
-						return false;
-					}
-
-					for (var i = 0; i < Enum.GetNames(a).Length; i++)
-					{
-						var nameA = Enum.GetNames(a)[i];
-						var nameB = Enum.GetNames(b)[i];
-
-						if (nameA != nameB)
-						{
-							return false;
-						}
-
-						var valueA = Convert.ChangeType(Enum.Parse(a, nameA), a.GetEnumUnderlyingType());
-						var valueB = Convert.ChangeType(Enum.Parse(b, nameB), b.GetEnumUnderlyingType());
-
-						if (!valueA.Equals(valueB))
-						{
-							return false;
-						}
-					}
-
-					return true;
+					return a.Name == b.Name
+						&& a.GetEnumUnderlyingType() == b.GetEnumUnderlyingType();
 				}
 
 				if (a.IsGenericParameter)


### PR DESCRIPTION
Removes the in-depth type checks on enums. This means that enums in APIs will accept any value, as long as the enum has the same name as uses the same underlying type. It will be up to the API vendors / consumers to handle unknown/deprecated/new values.