### PR TITLE
Add Donate Link Option To Manifest

### DIFF
--- a/schemas/manifest_schema.json
+++ b/schemas/manifest_schema.json
@@ -166,6 +166,11 @@
                     "description": "Description of the warning to show in the body of the dialog"
                 }
             }
+        },
+        "donateLink": {
+            "type": "string",
+            "description": "Provide a link for donations. This will appear as a button in the mod manager",
+            "pattern": "(?:^https://(?:www\\.)?patreon\\.com/\\w+$)|(?:^https://(?:www\\.)?paypal\\.me/\\w+$)"
         }
     }
 }


### PR DESCRIPTION
Adds `donateLink` to the manifest. This allows mod devs to specify a link that the manager will add a button for. Only Patreon and PayPal links are supported for security purposes.