### PR TITLE
2.11.0

### DIFF
--- a/src/OWML.Common/Interfaces/IModBehaviour.cs
+++ b/src/OWML.Common/Interfaces/IModBehaviour.cs
@@ -16,11 +16,23 @@ namespace OWML.Common
 
 		object GetApi();
 
-		void SetupTitleMenu();
+		/// <summary>
+		/// Called when the title screen has loaded in.
+		/// Put any code that edits the title menu here.
+		/// </summary>
+		void SetupTitleMenu(ITitleMenuManager titleManager);
 
-		void SetupPauseMenu();
+		/// <summary>
+		/// Called when the SolarSystem or EyeOfTheUniverse scene has loaded in.
+		/// Put any code that edits the pause menu here.
+		/// </summary>
+		void SetupPauseMenu(IPauseMenuManager pauseManager);
 
-		void SetupOptionsMenu();
+		/// <summary>
+		/// Called when the main menu or game has loaded in.
+		/// Put any code that edits the options menu here.
+		/// </summary>
+		void SetupOptionsMenu(IOptionsMenuManager optionsManager);
 
 		void Init(IModHelper helper);
 	}

--- a/src/OWML.Common/Interfaces/IModBehaviour.cs
+++ b/src/OWML.Common/Interfaces/IModBehaviour.cs
@@ -23,16 +23,31 @@ namespace OWML.Common
 		void SetupTitleMenu(ITitleMenuManager titleManager);
 
 		/// <summary>
+		/// Called when leaving the title menu scene. Put any event unsubscriptions here.
+		/// </summary>
+		void CleanupTitleMenu();
+
+		/// <summary>
 		/// Called when the SolarSystem or EyeOfTheUniverse scene has loaded in.
 		/// Put any code that edits the pause menu here.
 		/// </summary>
 		void SetupPauseMenu(IPauseMenuManager pauseManager);
 
 		/// <summary>
+		/// Called when leaving either game scene. Put any event unsubscriptions here.
+		/// </summary>
+		void CleanupPauseMenu();
+
+		/// <summary>
 		/// Called when the main menu or game has loaded in.
 		/// Put any code that edits the options menu here.
 		/// </summary>
 		void SetupOptionsMenu(IOptionsMenuManager optionsManager);
+
+		/// <summary>
+		/// Called when leaving the title or either game scene. Put any event unsubscriptions here.
+		/// </summary>
+		void CleanupOptionsMenu();
 
 		void Init(IModHelper helper);
 	}

--- a/src/OWML.Common/Interfaces/Menus/IOWMLFourChoicePopupMenu.cs
+++ b/src/OWML.Common/Interfaces/Menus/IOWMLFourChoicePopupMenu.cs
@@ -9,5 +9,8 @@
 		event PopupCancelEvent OnPopupCancel;
 
 		void EnableMenu(bool value);
+
+		public event Menu.ActivateMenuEvent OnActivateMenu;
+		public event Menu.DeactivateMenuEvent OnDeactivateMenu;
 	}
 }

--- a/src/OWML.Common/Interfaces/Menus/IOWMLPopupInputMenu.cs
+++ b/src/OWML.Common/Interfaces/Menus/IOWMLPopupInputMenu.cs
@@ -15,5 +15,7 @@ namespace OWML.Common.Interfaces.Menus
 		public void SetInputFieldPlaceholderText(string text);
 
 		public event PopupMenu.PopupConfirmEvent OnPopupConfirm;
+		public event Menu.ActivateMenuEvent OnActivateMenu;
+		public event Menu.DeactivateMenuEvent OnDeactivateMenu;
 	}
 }

--- a/src/OWML.Common/Interfaces/Menus/IOWMLPopupInputMenu.cs
+++ b/src/OWML.Common/Interfaces/Menus/IOWMLPopupInputMenu.cs
@@ -12,6 +12,8 @@ namespace OWML.Common.Interfaces.Menus
 
 		public InputField GetInputField();
 
+		public void SetInputFieldPlaceholderText(string text);
+
 		public event PopupMenu.PopupConfirmEvent OnPopupConfirm;
 	}
 }

--- a/src/OWML.Common/Interfaces/Menus/IOWMLThreeChoicePopupMenu.cs
+++ b/src/OWML.Common/Interfaces/Menus/IOWMLThreeChoicePopupMenu.cs
@@ -12,5 +12,8 @@
 		event PopupCancelEvent OnPopupCancel;
 
 		void EnableMenu(bool value);
+
+		public event Menu.ActivateMenuEvent OnActivateMenu;
+		public event Menu.DeactivateMenuEvent OnDeactivateMenu;
 	}
 }

--- a/src/OWML.Common/Interfaces/Menus/IPauseMenuManager.cs
+++ b/src/OWML.Common/Interfaces/Menus/IPauseMenuManager.cs
@@ -1,7 +1,20 @@
-﻿namespace OWML.Common
+﻿using System;
+using UnityEngine;
+
+namespace OWML.Common
 {
 	public interface IPauseMenuManager
 	{
+		/// <summary>
+		/// Called when the pause menu is opened.
+		/// </summary>
+		event Action PauseMenuOpened;
+
+		/// <summary>
+		/// Called when the pause menu is closed.
+		/// </summary>
+		event Action PauseMenuClosed;
+
 		/// <summary>
 		/// Makes another list of buttons that can be seen in the pause menu.
 		/// </summary>

--- a/src/OWML.Launcher/OWML.Manifest.json
+++ b/src/OWML.Launcher/OWML.Manifest.json
@@ -3,7 +3,7 @@
   "author": "Alek",
   "name": "OWML",
   "uniqueName": "Alek.OWML",
-  "version": "2.10.3",
+  "version": "2.10.4",
   "minGameVersion": "1.1.14.768",
   "maxGameVersion": "1.1.14.768"
 }

--- a/src/OWML.Launcher/OWML.Manifest.json
+++ b/src/OWML.Launcher/OWML.Manifest.json
@@ -3,7 +3,7 @@
   "author": "Alek",
   "name": "OWML",
   "uniqueName": "Alek.OWML",
-  "version": "2.10.4",
+  "version": "2.11.0",
   "minGameVersion": "1.1.14.768",
   "maxGameVersion": "1.1.14.768"
 }

--- a/src/OWML.ModHelper.Menus/NewMenuSystem/MenuManager.cs
+++ b/src/OWML.ModHelper.Menus/NewMenuSystem/MenuManager.cs
@@ -321,14 +321,14 @@ namespace OWML.ModHelper.Menus.NewMenuSystem
 				{
 					if (LoadManager.GetCurrentScene() == OWScene.TitleScreen)
 					{
-						mod.SetupTitleMenu();
+						mod.SetupTitleMenu(mod.ModHelper.MenuHelper.TitleMenuManager);
 					}
 					else if (LoadManager.GetCurrentScene() is OWScene.SolarSystem or OWScene.EyeOfTheUniverse)
 					{
-						mod.SetupPauseMenu();
+						mod.SetupPauseMenu(mod.ModHelper.MenuHelper.PauseMenuManager);
 					}
 
-					mod.SetupOptionsMenu();
+					mod.SetupOptionsMenu(mod.ModHelper.MenuHelper.OptionsMenuManager);
 				}
 				catch (Exception ex)
 				{

--- a/src/OWML.ModHelper.Menus/NewMenuSystem/MenuManager.cs
+++ b/src/OWML.ModHelper.Menus/NewMenuSystem/MenuManager.cs
@@ -58,6 +58,23 @@ namespace OWML.ModHelper.Menus.NewMenuSystem
 			var harmonyInstance = harmony.GetValue<Harmony>("_harmony");
 			harmonyInstance.PatchAll(typeof(Patches));
 
+			LoadManager.OnStartSceneLoad += (oldScene, newScene) =>
+			{
+				foreach (var mod in ((IMenuManager)this).ModList)
+				{
+					if (oldScene == OWScene.TitleScreen)
+					{
+						mod.CleanupTitleMenu();
+						mod.CleanupOptionsMenu();
+					}
+					else if (oldScene is OWScene.SolarSystem or OWScene.EyeOfTheUniverse)
+					{
+						mod.CleanupPauseMenu();
+						mod.CleanupOptionsMenu();
+					}
+				}
+			};
+
 			LoadManager.OnCompleteSceneLoad += (_, newScene) =>
 			{
 				_hasSetupMenusThisScene = false;

--- a/src/OWML.ModHelper.Menus/NewMenuSystem/MenuManager.cs
+++ b/src/OWML.ModHelper.Menus/NewMenuSystem/MenuManager.cs
@@ -38,6 +38,8 @@ namespace OWML.ModHelper.Menus.NewMenuSystem
 		internal static Menu OWMLSettingsMenu;
 		internal static List<(IModBehaviour behaviour, Menu modMenu)> ModSettingsMenus = new();
 
+		private bool _hasSetupMenusThisScene = false;
+
 		public MenuManager(
 			IModConsole console,
 			IHarmonyHelper harmony,
@@ -58,7 +60,8 @@ namespace OWML.ModHelper.Menus.NewMenuSystem
 
 			LoadManager.OnCompleteSceneLoad += (_, newScene) =>
 			{
-				if (newScene is  OWScene.SolarSystem or OWScene.EyeOfTheUniverse)
+				_hasSetupMenusThisScene = false;
+				if (newScene is OWScene.SolarSystem or OWScene.EyeOfTheUniverse)
 				{
 					SetupMenus(((IMenuManager)this).ModList);
 				}
@@ -67,6 +70,13 @@ namespace OWML.ModHelper.Menus.NewMenuSystem
 
 		internal void SetupMenus(IList<IModBehaviour> modList)
 		{
+			if (_hasSetupMenusThisScene)
+			{
+				return;
+			}
+
+			_hasSetupMenusThisScene = true;
+
 			void SaveConfig()
 			{
 				JsonHelper.SaveJsonObject($"{_owmlConfig.OWMLPath}{Constants.OwmlConfigFileName}", _owmlConfig);

--- a/src/OWML.ModHelper.Menus/NewMenuSystem/PauseMenuManager.cs
+++ b/src/OWML.ModHelper.Menus/NewMenuSystem/PauseMenuManager.cs
@@ -15,13 +15,39 @@ namespace OWML.ModHelper.Menus.NewMenuSystem
 	{
 		private IModConsole _console;
 		private FontAndLanguageController _languageController;
-
 		private GameObject _pauseMenuItemsTemplate;
 		private GameObject _buttonPrefab;
+
+		public event Action PauseMenuOpened;
+		public event Action PauseMenuClosed;
 
 		public PauseMenuManager(IModConsole console)
 		{
 			_console = console;
+			LoadManager.OnCompleteSceneLoad += OnSceneLoadCompleted;
+		}
+
+		private void OnSceneLoadCompleted(OWScene old, OWScene newScene)
+		{
+			if (newScene is OWScene.SolarSystem or OWScene.EyeOfTheUniverse)
+			{
+				var pauseMenuManager = Resources.FindObjectsOfTypeAll<global::PauseMenuManager>()[0];
+				pauseMenuManager._pauseMenu.OnActivateMenu += () =>
+				{
+					if (!pauseMenuManager.IsOpen())
+					{
+						PauseMenuOpened?.SafeInvoke();
+					}
+				};
+
+				pauseMenuManager._pauseMenu.OnDeactivateMenu += () =>
+				{
+					if (MenuStackManager.SharedInstance.GetMenuCount() == 0)
+					{
+						PauseMenuClosed?.SafeInvoke();
+					}
+				};
+			}
 		}
 
 		private void AddToLangController(Text textComponent)

--- a/src/OWML.ModHelper.Menus/NewMenuSystem/PauseMenuManager.cs
+++ b/src/OWML.ModHelper.Menus/NewMenuSystem/PauseMenuManager.cs
@@ -14,6 +14,7 @@ namespace OWML.ModHelper.Menus.NewMenuSystem
 	public class PauseMenuManager : IPauseMenuManager
 	{
 		private IModConsole _console;
+		private FontAndLanguageController _languageController;
 
 		private GameObject _pauseMenuItemsTemplate;
 		private GameObject _buttonPrefab;
@@ -21,6 +22,16 @@ namespace OWML.ModHelper.Menus.NewMenuSystem
 		public PauseMenuManager(IModConsole console)
 		{
 			_console = console;
+		}
+
+		private void AddToLangController(Text textComponent)
+		{
+			if (_languageController == null)
+			{
+				_languageController = Resources.FindObjectsOfTypeAll<global::PauseMenuManager>()[0].transform.GetChild(0).GetComponent<FontAndLanguageController>();
+			}
+
+			_languageController.AddTextElement(textComponent, false);
 		}
 
 		private void MakePauseMenuItemsTemplate()
@@ -89,6 +100,7 @@ namespace OWML.ModHelper.Menus.NewMenuSystem
 
 			SetButtonText(submitAction, name);
 			SetButtonIndex(submitAction, index, fromTop);
+			AddToLangController(submitAction.GetComponentInChildren<Text>());
 
 			return submitAction;
 		}
@@ -108,6 +120,7 @@ namespace OWML.ModHelper.Menus.NewMenuSystem
 
 			SetButtonText(submitActionMenu, name);
 			SetButtonIndex(submitActionMenu, index, fromTop);
+			AddToLangController(submitActionMenu.GetComponentInChildren<Text>());
 
 			menuRootObject.SetActive(true);
 			return submitActionMenu;

--- a/src/OWML.ModHelper.Menus/NewMenuSystem/TitleMenuManager.cs
+++ b/src/OWML.ModHelper.Menus/NewMenuSystem/TitleMenuManager.cs
@@ -10,6 +10,18 @@ namespace OWML.ModHelper.Menus.NewMenuSystem
 {
 	internal class TitleMenuManager : ITitleMenuManager
 	{
+		private FontAndLanguageController _languageController;
+
+		private void AddToLangController(Text textComponent)
+		{
+			if (_languageController == null)
+			{
+				_languageController = GameObject.Find("MainMenu").GetComponent<FontAndLanguageController>();
+			}
+
+			_languageController.AddTextElement(textComponent, false);
+		}
+
 		public SubmitAction CreateTitleButton(string text, int index, bool fromTop)
 		{
 			var titleScreenManager = Object.FindObjectOfType<TitleScreenManager>();
@@ -27,6 +39,7 @@ namespace OWML.ModHelper.Menus.NewMenuSystem
 
 			SetButtonIndex(submitAction, index, fromTop);
 			SetButtonText(submitAction, text);
+			AddToLangController(submitAction.GetComponentInChildren<Text>());
 
 			newButton.GetComponent<CanvasGroup>().alpha = 0;
 			var animController = GameObject.Find("TitleMenuManagers").GetComponent<TitleAnimationController>();

--- a/src/OWML.ModHelper/ModBehaviour.cs
+++ b/src/OWML.ModHelper/ModBehaviour.cs
@@ -24,17 +24,14 @@ namespace OWML.ModHelper
 
 		public virtual object GetApi() => null;
 
-		public virtual void SetupTitleMenu(ITitleMenuManager titleManager)
-		{
-		}
+		public virtual void SetupTitleMenu(ITitleMenuManager titleManager) { }
+		public virtual void CleanupTitleMenu() { }
 
-		public virtual void SetupPauseMenu(IPauseMenuManager pauseManager)
-		{
-		}
+		public virtual void SetupPauseMenu(IPauseMenuManager pauseManager) { }
+		public virtual void CleanupPauseMenu() { }
 
-		public virtual void SetupOptionsMenu(IOptionsMenuManager optionsManager)
-		{
-		}
+		public virtual void SetupOptionsMenu(IOptionsMenuManager optionsManager) { }
+		public virtual void CleanupOptionsMenu() { }
 
 		public IList<IModBehaviour> GetDependants() =>
 			ModHelper.Interaction.GetDependants(ModHelper.Manifest.UniqueName);

--- a/src/OWML.ModHelper/ModBehaviour.cs
+++ b/src/OWML.ModHelper/ModBehaviour.cs
@@ -24,15 +24,15 @@ namespace OWML.ModHelper
 
 		public virtual object GetApi() => null;
 
-		public virtual void SetupTitleMenu()
+		public virtual void SetupTitleMenu(ITitleMenuManager titleManager)
 		{
 		}
 
-		public virtual void SetupPauseMenu()
+		public virtual void SetupPauseMenu(IPauseMenuManager pauseManager)
 		{
 		}
 
-		public virtual void SetupOptionsMenu()
+		public virtual void SetupOptionsMenu(IOptionsMenuManager optionsManager)
 		{
 		}
 

--- a/src/OWML.Utils/MenuExtensions.cs
+++ b/src/OWML.Utils/MenuExtensions.cs
@@ -1,0 +1,7 @@
+﻿namespace OWML.Utils
+{
+	public static class MenuExtensions
+	{
+		public static void SetMessage(this PopupMenu menu, string message) => menu._labelText.text = message;
+	}
+}

--- a/src/OWML.Utils/MenuExtensions.cs
+++ b/src/OWML.Utils/MenuExtensions.cs
@@ -1,7 +1,27 @@
-﻿namespace OWML.Utils
+﻿using UnityEngine;
+
+namespace OWML.Utils
 {
 	public static class MenuExtensions
 	{
 		public static void SetMessage(this PopupMenu menu, string message) => menu._labelText.text = message;
+
+		public static void SetButtonVisible(this SubmitAction buttonAction, bool visible)
+		{
+			var activeAlpha = 1;
+
+			if (LoadManager.GetCurrentScene() == OWScene.TitleScreen)
+			{
+				var titleAnimationController = Resources.FindObjectsOfTypeAll<TitleScreenManager>()[0]._gfxController;
+				activeAlpha = titleAnimationController.IsTitleAnimationComplete() ? 1 : 0;
+				if (titleAnimationController.IsFadingInMenuOptions())
+				{
+					activeAlpha = 1;
+				}
+			}
+
+			buttonAction.gameObject.SetActive(visible);
+			buttonAction.GetComponent<CanvasGroup>().alpha = visible ? activeAlpha : 0;
+		}
 	}
 }

--- a/src/SampleMods/OWML.LoadCustomAssets/LoadCustomAssets.cs
+++ b/src/SampleMods/OWML.LoadCustomAssets/LoadCustomAssets.cs
@@ -50,30 +50,30 @@ namespace OWML.LoadCustomAssets
 			ModHelper.MenuHelper.PopupMenuManager.RegisterStartupPopup("Test Startup Popup");
 		}
 
-		public override void SetupTitleMenu()
+		public override void SetupTitleMenu(ITitleMenuManager titleManager)
 		{
-			var infoButton = ModHelper.MenuHelper.TitleMenuManager.CreateTitleButton("INFO POPUP");
+			var infoButton = titleManager.CreateTitleButton("INFO POPUP");
 			var infoPopup = ModHelper.MenuHelper.PopupMenuManager.CreateInfoPopup("test info popup", "yarp");
 			infoButton.OnSubmitAction += () => infoPopup.EnableMenu(true);
 
-			var twoChoiceButton = ModHelper.MenuHelper.TitleMenuManager.CreateTitleButton("TWO CHOICE");
+			var twoChoiceButton = titleManager.CreateTitleButton("TWO CHOICE");
 			var twoChoicePopup = ModHelper.MenuHelper.PopupMenuManager.CreateTwoChoicePopup("test two choice popup", "oak", "narp");
 			twoChoiceButton.OnSubmitAction += () => twoChoicePopup.EnableMenu(true);
 
-			var threeChoiceButton = ModHelper.MenuHelper.TitleMenuManager.CreateTitleButton("THREE CHOICE");
+			var threeChoiceButton = titleManager.CreateTitleButton("THREE CHOICE");
 			var threeChoicePopup = ModHelper.MenuHelper.PopupMenuManager.CreateThreeChoicePopup("test three choice popup", "oak", "oak (better)", "narp");
 			threeChoiceButton.OnSubmitAction += () => threeChoicePopup.EnableMenu(true);
 			threeChoicePopup.OnPopupConfirm1 += () => ModHelper.Console.WriteLine("Confirm 1");
 			threeChoicePopup.OnPopupConfirm2 += () => ModHelper.Console.WriteLine("Confirm 2");
 
-			var fourChoiceButton = ModHelper.MenuHelper.TitleMenuManager.CreateTitleButton("FOUR CHOICE");
+			var fourChoiceButton = titleManager.CreateTitleButton("FOUR CHOICE");
 			var fourChoicePopup = ModHelper.MenuHelper.PopupMenuManager.CreateFourChoicePopup("test four choice popup", "oak", "oak (better)", "oak (worse)", "narp");
 			fourChoiceButton.OnSubmitAction += () => fourChoicePopup.EnableMenu(true);
 			fourChoicePopup.OnPopupConfirm1 += () => ModHelper.Console.WriteLine("Confirm 1");
 			fourChoicePopup.OnPopupConfirm2 += () => ModHelper.Console.WriteLine("Confirm 2");
 			fourChoicePopup.OnPopupConfirm3 += () => ModHelper.Console.WriteLine("Confirm 3");
 
-			var textButton = ModHelper.MenuHelper.TitleMenuManager.CreateTitleButton("INPUT POPUP TEST");
+			var textButton = titleManager.CreateTitleButton("INPUT POPUP TEST");
 			var textPopup = ModHelper.MenuHelper.PopupMenuManager.CreateInputFieldPopup("test text popup", "type a funny thing!", "ok", "cancel");
 			textButton.OnSubmitAction += () => textPopup.EnableMenu(true);
 			textPopup.OnPopupConfirm += () =>
@@ -84,25 +84,25 @@ namespace OWML.LoadCustomAssets
 			
 		}
 
-		public override void SetupPauseMenu()
+		public override void SetupPauseMenu(IPauseMenuManager pauseManager)
 		{
-			var pauseMenuManager = ModHelper.MenuHelper.PauseMenuManager;
+			var listMenu = pauseManager.MakePauseListMenu("TEST");
+			var button = pauseManager.MakeMenuOpenButton("TEST", listMenu, 1, true);
 
-			var listMenu = pauseMenuManager.MakePauseListMenu("TEST");
-			var button = pauseMenuManager.MakeMenuOpenButton("TEST", listMenu, 1, true);
+			var button1 = pauseManager.MakeSimpleButton("1", 0, true, listMenu);
+			var button2 = pauseManager.MakeSimpleButton("2", 1, true, listMenu);
+			var button3 = pauseManager.MakeSimpleButton("3", 2, true, listMenu);
 
-			var button1 = pauseMenuManager.MakeSimpleButton("1", 0, true, listMenu);
-			var button2 = pauseMenuManager.MakeSimpleButton("2", 1, true, listMenu);
-			var button3 = pauseMenuManager.MakeSimpleButton("3", 2, true, listMenu);
+			pauseManager.PauseMenuOpened += () => ModHelper.Console.WriteLine($"PAUSE MENU OPENED!", MessageType.Success);
+			pauseManager.PauseMenuClosed += () => ModHelper.Console.WriteLine($"PAUSE MENU CLOSED!", MessageType.Success);
 		}
 
-		public override void SetupOptionsMenu()
+		public override void SetupOptionsMenu(IOptionsMenuManager optionsManager)
 		{
 			var infoPopup = ModHelper.MenuHelper.PopupMenuManager.CreateInfoPopup("test info popup", "yarp");
 			var twoChoicePopup = ModHelper.MenuHelper.PopupMenuManager.CreateTwoChoicePopup("test two choice popup", "oak", "narp");
 			var threeChoicePopup = ModHelper.MenuHelper.PopupMenuManager.CreateThreeChoicePopup("test three choice popup", "oak", "oak (better)", "narp");
 
-			var optionsManager = ModHelper.MenuHelper.OptionsMenuManager;
 			var (tabMenu, tabButton) = optionsManager.CreateTabWithSubTabs("TEST");
 			var (subTab1Menu, subTab1Button) = optionsManager.AddSubTab(tabMenu, "TAB 1");
 			var (subTab2Menu, subTab2Button) = optionsManager.AddSubTab(tabMenu, "TAB 2");

--- a/src/SampleMods/OWML.LoadCustomAssets/LoadCustomAssets.cs
+++ b/src/SampleMods/OWML.LoadCustomAssets/LoadCustomAssets.cs
@@ -55,16 +55,22 @@ namespace OWML.LoadCustomAssets
 			var infoButton = titleManager.CreateTitleButton("INFO POPUP");
 			var infoPopup = ModHelper.MenuHelper.PopupMenuManager.CreateInfoPopup("test info popup", "yarp");
 			infoButton.OnSubmitAction += () => infoPopup.EnableMenu(true);
+			infoPopup.OnActivateMenu += () => ModHelper.Console.WriteLine("info popup activate");
+			infoPopup.OnDeactivateMenu += () => ModHelper.Console.WriteLine("info popup deactivate");
 
 			var twoChoiceButton = titleManager.CreateTitleButton("TWO CHOICE");
 			var twoChoicePopup = ModHelper.MenuHelper.PopupMenuManager.CreateTwoChoicePopup("test two choice popup", "oak", "narp");
 			twoChoiceButton.OnSubmitAction += () => twoChoicePopup.EnableMenu(true);
+			twoChoicePopup.OnActivateMenu += () => ModHelper.Console.WriteLine("two popup activate");
+			twoChoicePopup.OnDeactivateMenu += () => ModHelper.Console.WriteLine("two popup deactivate");
 
 			var threeChoiceButton = titleManager.CreateTitleButton("THREE CHOICE");
 			var threeChoicePopup = ModHelper.MenuHelper.PopupMenuManager.CreateThreeChoicePopup("test three choice popup", "oak", "oak (better)", "narp");
 			threeChoiceButton.OnSubmitAction += () => threeChoicePopup.EnableMenu(true);
 			threeChoicePopup.OnPopupConfirm1 += () => ModHelper.Console.WriteLine("Confirm 1");
 			threeChoicePopup.OnPopupConfirm2 += () => ModHelper.Console.WriteLine("Confirm 2");
+			threeChoicePopup.OnActivateMenu += () => ModHelper.Console.WriteLine("three popup activate");
+			threeChoicePopup.OnDeactivateMenu += () => ModHelper.Console.WriteLine("three popup deactivate");
 
 			var fourChoiceButton = titleManager.CreateTitleButton("FOUR CHOICE");
 			var fourChoicePopup = ModHelper.MenuHelper.PopupMenuManager.CreateFourChoicePopup("test four choice popup", "oak", "oak (better)", "oak (worse)", "narp");
@@ -72,6 +78,8 @@ namespace OWML.LoadCustomAssets
 			fourChoicePopup.OnPopupConfirm1 += () => ModHelper.Console.WriteLine("Confirm 1");
 			fourChoicePopup.OnPopupConfirm2 += () => ModHelper.Console.WriteLine("Confirm 2");
 			fourChoicePopup.OnPopupConfirm3 += () => ModHelper.Console.WriteLine("Confirm 3");
+			fourChoicePopup.OnActivateMenu += () => ModHelper.Console.WriteLine("four popup activate");
+			fourChoicePopup.OnDeactivateMenu += () => ModHelper.Console.WriteLine("four popup deactivate");
 
 			var textButton = titleManager.CreateTitleButton("INPUT POPUP TEST");
 			var textPopup = ModHelper.MenuHelper.PopupMenuManager.CreateInputFieldPopup("test text popup", "type a funny thing!", "ok", "cancel");
@@ -81,7 +89,8 @@ namespace OWML.LoadCustomAssets
 				ModHelper.Console.WriteLine(textPopup.GetInputText());
 			};
 
-			
+			textPopup.OnActivateMenu += () => ModHelper.Console.WriteLine("text popup activate");
+			textPopup.OnDeactivateMenu += () => ModHelper.Console.WriteLine("text popup deactivate");
 		}
 
 		public override void CleanupTitleMenu()

--- a/src/SampleMods/OWML.LoadCustomAssets/LoadCustomAssets.cs
+++ b/src/SampleMods/OWML.LoadCustomAssets/LoadCustomAssets.cs
@@ -84,6 +84,11 @@ namespace OWML.LoadCustomAssets
 			
 		}
 
+		public override void CleanupTitleMenu()
+		{
+			ModHelper.Console.WriteLine($"CLEANUP TITLE MENU");
+		}
+
 		public override void SetupPauseMenu(IPauseMenuManager pauseManager)
 		{
 			var listMenu = pauseManager.MakePauseListMenu("TEST");
@@ -93,8 +98,24 @@ namespace OWML.LoadCustomAssets
 			var button2 = pauseManager.MakeSimpleButton("2", 1, true, listMenu);
 			var button3 = pauseManager.MakeSimpleButton("3", 2, true, listMenu);
 
-			pauseManager.PauseMenuOpened += () => ModHelper.Console.WriteLine($"PAUSE MENU OPENED!", MessageType.Success);
-			pauseManager.PauseMenuClosed += () => ModHelper.Console.WriteLine($"PAUSE MENU CLOSED!", MessageType.Success);
+			pauseManager.PauseMenuOpened += LogOpened;
+			pauseManager.PauseMenuClosed += LogClosed;
+		}
+
+		public override void CleanupPauseMenu()
+		{
+			ModHelper.MenuHelper.PauseMenuManager.PauseMenuOpened -= LogOpened;
+			ModHelper.MenuHelper.PauseMenuManager.PauseMenuClosed -= LogClosed;
+		}
+
+		private void LogOpened()
+		{
+			ModHelper.Console.WriteLine($"PAUSE MENU OPENED!", MessageType.Success);
+		}
+
+		private void LogClosed()
+		{
+			ModHelper.Console.WriteLine($"PAUSE MENU CLOSED!", MessageType.Success);
 		}
 
 		public override void SetupOptionsMenu(IOptionsMenuManager optionsManager)
@@ -118,6 +139,11 @@ namespace OWML.LoadCustomAssets
 			var toggle = optionsManager.AddToggleInput(subTab2Menu, "Test Toggle", "Option 1", "Option 2", "* It's a test toggle.", false);
 			var selector = optionsManager.AddSelectorInput(subTab2Menu, "Test Selector", new[] { "Option 1", "Option 2", "Option 3" }, "* It's a test selector.", true, 0);
 			var slider = optionsManager.AddSliderInput(subTab2Menu, "Test Slider", 0, 100, "* It's a test slider.", 50);
+		}
+
+		public override void CleanupOptionsMenu()
+		{
+			ModHelper.Console.WriteLine($"CLEANUP OPTIONS MENU");
 		}
 
 		private void TestAPI()


### PR DESCRIPTION
- Added `SetInputFieldPlaceholderText(string)` to `IOWMLPopupInputMenu`.
- Added the `SetMessage(string)` extension for all popup menus.
- Added the `SetButtonVisible(bool)` extension for all buttons.
- Added title & pause buttons to the language controller, which swaps out their font when a language is changed. Popup menus and option menu items will be added to this in the next update.
- Fixed `SetupTitleMenu` being called multiple times due to the gamma popup.
- Added `CleanupTitleMenu`, `CleanupPauseMenu`, `CleanupOptionsMenu` for event unsubscriptions to happen in.
- Managers are now passed to `Setup` methods.
- Added `PauseMenuOpened` and `PauseMenuClosed` events to PauseMenuManager.
- Added `OnActivateMenu` and `OnDeactivateMenu` to popups.