### PR TITLE
2.12.0

### DIFF
--- a/docs/content/pages/guides/mod_settings.md
+++ b/docs/content/pages/guides/mod_settings.md
@@ -138,3 +138,22 @@ public class MyMod : ModBehaviour {
 ## Config Updates
 
 Something important to note is that when the manager pulls and update for your mod, the `config.json` file is preserved. The issue with this is menus are generated from the `config.json` file. When changing options like slider minimums and maximums or choices, you may want to create a new property rather than edit an existing one to make sure the UI is correct.
+
+## Translations
+
+Mod config options can be translated in the same way that [New Horizons mods do translations](https://nh.outerwildsmods.com/guides/translation/). First, you need to add a folder named `translations` in the root directory of your mod.
+
+There are 12 supported languages in Outer Wilds: `english`, `spanish_la`, `german`, `french`, `italian`, `polish`, `portuguese_br`, `japanese`, `russian`, `chinese_simple`, `korean`, and `turkish`.
+
+In the `translations` folder you can put json files with the name of the language you want to translate for. This file will contain a single dictionary named `UIDictionary` which will have key-value pairs for the translation.
+
+```json
+{
+    "UIDictionary": {
+        "settingTitle": "My Translated Title",
+        "settingTooltip": "My Translated Tooltip"
+    }
+}
+```
+
+If your mod already uses New Horizons and supports translations, these values are added directly into the same translation files that NH uses.

--- a/src/OWML.Common/Interfaces/IModBehaviour.cs
+++ b/src/OWML.Common/Interfaces/IModBehaviour.cs
@@ -23,16 +23,31 @@ namespace OWML.Common
 		void SetupTitleMenu(ITitleMenuManager titleManager);
 
 		/// <summary>
+		/// Called when leaving the title menu scene. Put any event unsubscriptions here.
+		/// </summary>
+		void CleanupTitleMenu();
+
+		/// <summary>
 		/// Called when the SolarSystem or EyeOfTheUniverse scene has loaded in.
 		/// Put any code that edits the pause menu here.
 		/// </summary>
 		void SetupPauseMenu(IPauseMenuManager pauseManager);
 
 		/// <summary>
+		/// Called when leaving either game scene. Put any event unsubscriptions here.
+		/// </summary>
+		void CleanupPauseMenu();
+
+		/// <summary>
 		/// Called when the main menu or game has loaded in.
 		/// Put any code that edits the options menu here.
 		/// </summary>
 		void SetupOptionsMenu(IOptionsMenuManager optionsManager);
+
+		/// <summary>
+		/// Called when leaving the title or either game scene. Put any event unsubscriptions here.
+		/// </summary>
+		void CleanupOptionsMenu();
 
 		void Init(IModHelper helper);
 	}

--- a/src/OWML.Common/Interfaces/Menus/IOWMLFourChoicePopupMenu.cs
+++ b/src/OWML.Common/Interfaces/Menus/IOWMLFourChoicePopupMenu.cs
@@ -9,5 +9,8 @@
 		event PopupCancelEvent OnPopupCancel;
 
 		void EnableMenu(bool value);
+
+		public event Menu.ActivateMenuEvent OnActivateMenu;
+		public event Menu.DeactivateMenuEvent OnDeactivateMenu;
 	}
 }

--- a/src/OWML.Common/Interfaces/Menus/IOWMLPopupInputMenu.cs
+++ b/src/OWML.Common/Interfaces/Menus/IOWMLPopupInputMenu.cs
@@ -15,5 +15,7 @@ namespace OWML.Common.Interfaces.Menus
 		public void SetInputFieldPlaceholderText(string text);
 
 		public event PopupMenu.PopupConfirmEvent OnPopupConfirm;
+		public event Menu.ActivateMenuEvent OnActivateMenu;
+		public event Menu.DeactivateMenuEvent OnDeactivateMenu;
 	}
 }

--- a/src/OWML.Common/Interfaces/Menus/IOWMLThreeChoicePopupMenu.cs
+++ b/src/OWML.Common/Interfaces/Menus/IOWMLThreeChoicePopupMenu.cs
@@ -12,5 +12,8 @@
 		event PopupCancelEvent OnPopupCancel;
 
 		void EnableMenu(bool value);
+
+		public event Menu.ActivateMenuEvent OnActivateMenu;
+		public event Menu.DeactivateMenuEvent OnDeactivateMenu;
 	}
 }

--- a/src/OWML.Launcher/OWML.Manifest.json
+++ b/src/OWML.Launcher/OWML.Manifest.json
@@ -3,7 +3,7 @@
   "author": "Alek",
   "name": "OWML",
   "uniqueName": "Alek.OWML",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "minGameVersion": "1.1.14.768",
   "maxGameVersion": "1.1.14.768"
 }

--- a/src/OWML.Launcher/OWML.Manifest.json
+++ b/src/OWML.Launcher/OWML.Manifest.json
@@ -3,7 +3,7 @@
   "author": "Alek",
   "name": "OWML",
   "uniqueName": "Alek.OWML",
-  "version": "2.10.4",
+  "version": "2.11.0",
   "minGameVersion": "1.1.14.768",
   "maxGameVersion": "1.1.14.768"
 }

--- a/src/OWML.Launcher/OWML.Manifest.json
+++ b/src/OWML.Launcher/OWML.Manifest.json
@@ -3,7 +3,7 @@
   "author": "Alek",
   "name": "OWML",
   "uniqueName": "Alek.OWML",
-  "version": "2.11.1",
+  "version": "2.12.0",
   "minGameVersion": "1.1.14.768",
   "maxGameVersion": "1.1.14.768"
 }

--- a/src/OWML.ModHelper.Menus/NewMenuSystem/MenuManager.cs
+++ b/src/OWML.ModHelper.Menus/NewMenuSystem/MenuManager.cs
@@ -221,6 +221,14 @@ namespace OWML.ModHelper.Menus.NewMenuSystem
 
 						var settingObject = setting as JObject;
 
+						if (settingObject["dlcOnly"].ToObject<bool>())
+						{
+							if (EntitlementsManager.IsDlcOwned() == EntitlementsManager.AsyncOwnershipStatus.NotOwned)
+							{
+								continue;
+							}
+						}
+
 						if (settingObject != default(JObject))
 						{
 							if (settingObject["title"] != null)

--- a/src/OWML.ModHelper.Menus/NewMenuSystem/MenuManager.cs
+++ b/src/OWML.ModHelper.Menus/NewMenuSystem/MenuManager.cs
@@ -58,6 +58,23 @@ namespace OWML.ModHelper.Menus.NewMenuSystem
 			var harmonyInstance = harmony.GetValue<Harmony>("_harmony");
 			harmonyInstance.PatchAll(typeof(Patches));
 
+			LoadManager.OnStartSceneLoad += (oldScene, newScene) =>
+			{
+				foreach (var mod in ((IMenuManager)this).ModList)
+				{
+					if (oldScene == OWScene.TitleScreen)
+					{
+						mod.CleanupTitleMenu();
+						mod.CleanupOptionsMenu();
+					}
+					else if (oldScene is OWScene.SolarSystem or OWScene.EyeOfTheUniverse)
+					{
+						mod.CleanupPauseMenu();
+						mod.CleanupOptionsMenu();
+					}
+				}
+			};
+
 			LoadManager.OnCompleteSceneLoad += (_, newScene) =>
 			{
 				_hasSetupMenusThisScene = false;

--- a/src/OWML.ModHelper/ModBehaviour.cs
+++ b/src/OWML.ModHelper/ModBehaviour.cs
@@ -24,17 +24,14 @@ namespace OWML.ModHelper
 
 		public virtual object GetApi() => null;
 
-		public virtual void SetupTitleMenu(ITitleMenuManager titleManager)
-		{
-		}
+		public virtual void SetupTitleMenu(ITitleMenuManager titleManager) { }
+		public virtual void CleanupTitleMenu() { }
 
-		public virtual void SetupPauseMenu(IPauseMenuManager pauseManager)
-		{
-		}
+		public virtual void SetupPauseMenu(IPauseMenuManager pauseManager) { }
+		public virtual void CleanupPauseMenu() { }
 
-		public virtual void SetupOptionsMenu(IOptionsMenuManager optionsManager)
-		{
-		}
+		public virtual void SetupOptionsMenu(IOptionsMenuManager optionsManager) { }
+		public virtual void CleanupOptionsMenu() { }
 
 		public IList<IModBehaviour> GetDependants() =>
 			ModHelper.Interaction.GetDependants(ModHelper.Manifest.UniqueName);

--- a/src/OWML.Utils/MenuExtensions.cs
+++ b/src/OWML.Utils/MenuExtensions.cs
@@ -1,7 +1,27 @@
-﻿namespace OWML.Utils
+﻿using UnityEngine;
+
+namespace OWML.Utils
 {
 	public static class MenuExtensions
 	{
 		public static void SetMessage(this PopupMenu menu, string message) => menu._labelText.text = message;
+
+		public static void SetButtonVisible(this SubmitAction buttonAction, bool visible)
+		{
+			var activeAlpha = 1;
+
+			if (LoadManager.GetCurrentScene() == OWScene.TitleScreen)
+			{
+				var titleAnimationController = Resources.FindObjectsOfTypeAll<TitleScreenManager>()[0]._gfxController;
+				activeAlpha = titleAnimationController.IsTitleAnimationComplete() ? 1 : 0;
+				if (titleAnimationController.IsFadingInMenuOptions())
+				{
+					activeAlpha = 1;
+				}
+			}
+
+			buttonAction.gameObject.SetActive(visible);
+			buttonAction.GetComponent<CanvasGroup>().alpha = visible ? activeAlpha : 0;
+		}
 	}
 }

--- a/src/OWML.Utils/OWML.Utils.csproj
+++ b/src/OWML.Utils/OWML.Utils.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net48</TargetFramework>
     <LangVersion>9.0</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SampleMods/OWML.LoadCustomAssets/LoadCustomAssets.cs
+++ b/src/SampleMods/OWML.LoadCustomAssets/LoadCustomAssets.cs
@@ -55,16 +55,22 @@ namespace OWML.LoadCustomAssets
 			var infoButton = titleManager.CreateTitleButton("INFO POPUP");
 			var infoPopup = ModHelper.MenuHelper.PopupMenuManager.CreateInfoPopup("test info popup", "yarp");
 			infoButton.OnSubmitAction += () => infoPopup.EnableMenu(true);
+			infoPopup.OnActivateMenu += () => ModHelper.Console.WriteLine("info popup activate");
+			infoPopup.OnDeactivateMenu += () => ModHelper.Console.WriteLine("info popup deactivate");
 
 			var twoChoiceButton = titleManager.CreateTitleButton("TWO CHOICE");
 			var twoChoicePopup = ModHelper.MenuHelper.PopupMenuManager.CreateTwoChoicePopup("test two choice popup", "oak", "narp");
 			twoChoiceButton.OnSubmitAction += () => twoChoicePopup.EnableMenu(true);
+			twoChoicePopup.OnActivateMenu += () => ModHelper.Console.WriteLine("two popup activate");
+			twoChoicePopup.OnDeactivateMenu += () => ModHelper.Console.WriteLine("two popup deactivate");
 
 			var threeChoiceButton = titleManager.CreateTitleButton("THREE CHOICE");
 			var threeChoicePopup = ModHelper.MenuHelper.PopupMenuManager.CreateThreeChoicePopup("test three choice popup", "oak", "oak (better)", "narp");
 			threeChoiceButton.OnSubmitAction += () => threeChoicePopup.EnableMenu(true);
 			threeChoicePopup.OnPopupConfirm1 += () => ModHelper.Console.WriteLine("Confirm 1");
 			threeChoicePopup.OnPopupConfirm2 += () => ModHelper.Console.WriteLine("Confirm 2");
+			threeChoicePopup.OnActivateMenu += () => ModHelper.Console.WriteLine("three popup activate");
+			threeChoicePopup.OnDeactivateMenu += () => ModHelper.Console.WriteLine("three popup deactivate");
 
 			var fourChoiceButton = titleManager.CreateTitleButton("FOUR CHOICE");
 			var fourChoicePopup = ModHelper.MenuHelper.PopupMenuManager.CreateFourChoicePopup("test four choice popup", "oak", "oak (better)", "oak (worse)", "narp");
@@ -72,6 +78,8 @@ namespace OWML.LoadCustomAssets
 			fourChoicePopup.OnPopupConfirm1 += () => ModHelper.Console.WriteLine("Confirm 1");
 			fourChoicePopup.OnPopupConfirm2 += () => ModHelper.Console.WriteLine("Confirm 2");
 			fourChoicePopup.OnPopupConfirm3 += () => ModHelper.Console.WriteLine("Confirm 3");
+			fourChoicePopup.OnActivateMenu += () => ModHelper.Console.WriteLine("four popup activate");
+			fourChoicePopup.OnDeactivateMenu += () => ModHelper.Console.WriteLine("four popup deactivate");
 
 			var textButton = titleManager.CreateTitleButton("INPUT POPUP TEST");
 			var textPopup = ModHelper.MenuHelper.PopupMenuManager.CreateInputFieldPopup("test text popup", "type a funny thing!", "ok", "cancel");
@@ -81,7 +89,8 @@ namespace OWML.LoadCustomAssets
 				ModHelper.Console.WriteLine(textPopup.GetInputText());
 			};
 
-			
+			textPopup.OnActivateMenu += () => ModHelper.Console.WriteLine("text popup activate");
+			textPopup.OnDeactivateMenu += () => ModHelper.Console.WriteLine("text popup deactivate");
 		}
 
 		public override void CleanupTitleMenu()

--- a/src/SampleMods/OWML.LoadCustomAssets/LoadCustomAssets.cs
+++ b/src/SampleMods/OWML.LoadCustomAssets/LoadCustomAssets.cs
@@ -84,6 +84,11 @@ namespace OWML.LoadCustomAssets
 			
 		}
 
+		public override void CleanupTitleMenu()
+		{
+			ModHelper.Console.WriteLine($"CLEANUP TITLE MENU");
+		}
+
 		public override void SetupPauseMenu(IPauseMenuManager pauseManager)
 		{
 			var listMenu = pauseManager.MakePauseListMenu("TEST");
@@ -93,8 +98,24 @@ namespace OWML.LoadCustomAssets
 			var button2 = pauseManager.MakeSimpleButton("2", 1, true, listMenu);
 			var button3 = pauseManager.MakeSimpleButton("3", 2, true, listMenu);
 
-			pauseManager.PauseMenuOpened += () => ModHelper.Console.WriteLine($"PAUSE MENU OPENED!", MessageType.Success);
-			pauseManager.PauseMenuClosed += () => ModHelper.Console.WriteLine($"PAUSE MENU CLOSED!", MessageType.Success);
+			pauseManager.PauseMenuOpened += LogOpened;
+			pauseManager.PauseMenuClosed += LogClosed;
+		}
+
+		public override void CleanupPauseMenu()
+		{
+			ModHelper.MenuHelper.PauseMenuManager.PauseMenuOpened -= LogOpened;
+			ModHelper.MenuHelper.PauseMenuManager.PauseMenuClosed -= LogClosed;
+		}
+
+		private void LogOpened()
+		{
+			ModHelper.Console.WriteLine($"PAUSE MENU OPENED!", MessageType.Success);
+		}
+
+		private void LogClosed()
+		{
+			ModHelper.Console.WriteLine($"PAUSE MENU CLOSED!", MessageType.Success);
 		}
 
 		public override void SetupOptionsMenu(IOptionsMenuManager optionsManager)
@@ -118,6 +139,11 @@ namespace OWML.LoadCustomAssets
 			var toggle = optionsManager.AddToggleInput(subTab2Menu, "Test Toggle", "Option 1", "Option 2", "* It's a test toggle.", false);
 			var selector = optionsManager.AddSelectorInput(subTab2Menu, "Test Selector", new[] { "Option 1", "Option 2", "Option 3" }, "* It's a test selector.", true, 0);
 			var slider = optionsManager.AddSliderInput(subTab2Menu, "Test Slider", 0, 100, "* It's a test slider.", 50);
+		}
+
+		public override void CleanupOptionsMenu()
+		{
+			ModHelper.Console.WriteLine($"CLEANUP OPTIONS MENU");
 		}
 
 		private void TestAPI()


### PR DESCRIPTION
- Mod config settings now support translations. OWML will look for files named after the `TextTranslation.Language` enums in base game in a folder named `translations` where your mod is installed. Eg, `translations/english.json`. These files will follow the same format as New Horizons translations, and the `UIDictionary` will be used to store key-value pairs for your translation results. Translations support the `title` and `tooltip` fields for a setting, and if the title is absent it will use the setting's ID as a key. Check the OWML settings documentation for more info.
- Added `dlcOnly` support to settings that should only appear when Echoes of the Eye is installed.