### PR TITLE
Add Unpatching

### DIFF
--- a/.idea/.idea.OWML/.idea/.gitignore
+++ b/.idea/.idea.OWML/.idea/.gitignore
@@ -1,0 +1,13 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Rider ignored files
+/contentModel.xml
+/projectSettingsUpdater.xml
+/.idea.OWML.iml
+/modules.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/.idea.OWML/.idea/encodings.xml
+++ b/.idea/.idea.OWML/.idea/encodings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding" addBOMForNewFiles="with BOM under Windows, with no BOM otherwise" />
+</project>

--- a/.idea/.idea.OWML/.idea/indexLayout.xml
+++ b/.idea/.idea.OWML/.idea/indexLayout.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="UserContentModel">
+    <attachedFolders />
+    <explicitIncludes />
+    <explicitExcludes />
+  </component>
+</project>

--- a/.idea/.idea.OWML/.idea/vcs.xml
+++ b/.idea/.idea.OWML/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/docs/content/pages/guides/apis.md
+++ b/docs/content/pages/guides/apis.md
@@ -5,11 +5,11 @@ Sort_Priority: 35
 
 # Creating APIs
 
-To allow for easy interoperability between mods, OWML provides an API system where mods can provide and consume APIs from eachother easily.
+To allow for easy interoperability between mods, OWML provides an API system where mods can provide and consume APIs from each other easily.
 
 ## Creating an API
 
-To create an API start by making an interface with all the methods your api will have. 
+To create an API start by making an interface with all the methods your api will have.
 
 ```csharp
 public interface IMyCoolApi {
@@ -57,4 +57,3 @@ public class MyCoolMod : ModBehaviour {
     }
 }
 ```
-

--- a/docs/content/pages/guides/prepatchers.md
+++ b/docs/content/pages/guides/prepatchers.md
@@ -64,4 +64,4 @@ They work exactly like prepatchers and are passed the same thing.
 Setup for an unpatcher is exactly the same as a prepatcher, just set the `unpatcher` field in your manifest to the path of the executable.
 
 !!! alert-warning "Warning"
-    OWML tries its best to only run an unpatcher if your mod was previously enabled, however, it's possible for a unpatcher to run when the corresponding prepatcher didn't, so make sure your unpatcher can handle a state where the mod was never enabled i.e. checking a file exists before deleting it or checking if a file has been modified before reverting it.
+    OWML tries its best to only run an unpatcher if your mod was previously enabled. However, an unpatcher can run when the corresponding prepatcher doesn't. It's important to make sure your unpatcher can handle a state where the mod was never enabled. You can do this by checking if a file exists before deleting it, checking if a file has been modified before reverting it, etc.

--- a/docs/content/pages/guides/prepatchers.md
+++ b/docs/content/pages/guides/prepatchers.md
@@ -37,7 +37,7 @@ You'll need to have the prepatcher include libraries like Newtonsoft.Json to rea
 ### Logging
 
 Due to not having access to ModHelper, you'll need to use `Console.WriteLine` to log information.
-This **will not output to the manager window** to test prepatchers, we recommend you launch `OWML.Launcher.exe` in a
+This **will not output to the manager window** to test prepatchers. We recommend you launch `OWML.Launcher.exe` in a
 terminal directly to properly see stdout.
 
 If a prepatcher errors it *should usually* be outputted to the manage window as OWML is setup to catch and

--- a/docs/content/pages/guides/prepatchers.md
+++ b/docs/content/pages/guides/prepatchers.md
@@ -1,0 +1,67 @@
+---
+Title: Prepatchers
+Sort_Priority: 33
+---
+
+# Prepatchers
+
+In certain contexts you may need to edit game files before the game starts. This is where
+prepatchers come in. Prepatchers are run by OWML directly before a game starts, allowing you to modify game files.
+
+To create a prepatcher you'll need a separate project from your mod. This can be done by creating a new project in your solution with the executable type, it should automatically build to your mod folder.
+
+Now in your mod manifest you need to set the `patcher` field to the path of the executable relative to the root of the
+mod folder.
+
+## Creating A Prepatcher
+
+A prepatcher is a simple console app that OWML executes, it's only passed the location of your mod folder.
+However, it is possible to get the game's location by doing `AppDomain.CurrentDomain.BaseDirectory`:
+
+```csharp
+public static void Main(string[] args)
+{
+    var modPath = args.Length > 0 ? args[0] : ".";
+    var gamePath = AppDomain.CurrentDomain.BaseDirectory;
+
+    Console.WriteLine($"Mod Path: {modPath}");
+    Console.WriteLine($"Game Path: {gamePath}");
+
+    // DoStuff(modPath, gamePath);
+}
+```
+
+Keep in mind unlike in a ModBehaviour class the `ModHelper` is not available in a prepatcher.
+You'll need to have the prepatcher include libraries like Newtonsoft.Json to read and write JSON files.
+
+### Logging
+
+Due to not having access to ModHelper, you'll need to use `Console.WriteLine` to log information.
+This **will not output to the manager window** to test prepatchers, we recommend you launch `OWML.Launcher.exe` in a
+terminal directly to properly see stdout.
+
+If a prepatcher errors it *should usually* be outputted to the manage window as OWML is setup to catch and
+log any exceptions thrown by the prepatcher.
+
+### Warnings
+
+Due to the nature of prepatchers, the manager cannot undo changes made by them. This means if a prepatcher runs
+and doesn't have an [unpatcher](#unpatching) to revert the changes, the game will continue to be modified even if the
+mod is uninstalled or disabled.
+
+The manager will try it's best to warn the user of this. If your mod has prepatcher and
+is disabled or uninstalled the manager will show a dialog explaining that
+your mod has modified game files in an irreversible way and encourages them to validate the game files.
+
+If your mod uses an unpatcher the manager will forgo showing this dialog **on disable**, but will still show it on uninstall
+as at that point your mod cannot have its unpatcher run.
+
+## Unpatching
+
+OWML can also run an "unpatcher", this is another executable that is run when OWML launches if you're mod has been disabled.
+They work exactly like prepatchers and are passed the same thing.
+
+Setup for an unpatcher is exactly the same as a prepatcher, just set the `unpatcher` field in your manifest to the path of the executable.
+
+!!! alert-warning "Warning"
+    OWML tries its best to only run an unpatcher if your mod was previously enabled, however, it's possible for a unpatcher to run when the corresponding prepatcher didn't, so make sure your unpatcher can handle a state where the mod was never enabled i.e. checking a file exists before deleting it or checking if a file has been modified before reverting it.

--- a/schemas/manifest_schema.json
+++ b/schemas/manifest_schema.json
@@ -23,6 +23,10 @@
             "type": "string",
             "description": "The path to the patcher to use"
         },
+        "unpatcher": {
+            "type": "string",
+            "description": "The path to the unpatcher to use"
+        },
         "author": {
             "type": "string",
             "description": "The author of the mod",

--- a/src/OWML.Common/Interfaces/IModManifest.cs
+++ b/src/OWML.Common/Interfaces/IModManifest.cs
@@ -7,6 +7,7 @@ namespace OWML.Common
 		string Filename { get; }
 
 		string Patcher { get; }
+		string Unpatcher { get; }
 
 		string Author { get; }
 
@@ -19,6 +20,8 @@ namespace OWML.Common
 		string AssemblyPath { get; }
 
 		string PatcherPath { get; }
+
+		string UnpatcherPath { get;  }
 
 		string UniqueName { get; }
 

--- a/src/OWML.Common/Interfaces/IOwmlConfig.cs
+++ b/src/OWML.Common/Interfaces/IOwmlConfig.cs
@@ -25,5 +25,7 @@
 		bool IncrementalGC { get; set; }
 
 		int SocketPort { get; set; }
+
+		string[] PrepatchersExecuted { get; set; }
 	}
 }

--- a/src/OWML.Common/ModManifest.cs
+++ b/src/OWML.Common/ModManifest.cs
@@ -10,6 +10,9 @@ namespace OWML.Common
 
 		[JsonProperty("patcher")]
 		public string Patcher { get; private set; }
+		
+		[JsonProperty("unpatcher")] 
+		public string Unpatcher { get; private set; }
 
 		[JsonProperty("author")]
 		public string Author { get; private set; }
@@ -40,6 +43,9 @@ namespace OWML.Common
 
 		[JsonIgnore]
 		public string PatcherPath => ModFolderPath + Patcher;
+
+		[JsonIgnore] 
+		public string UnpatcherPath => ModFolderPath + Unpatcher;
 
 		[JsonProperty("minGameVersion")]
 		public string MinGameVersion { get; private set; } = "";

--- a/src/OWML.Common/OwmlConfig.cs
+++ b/src/OWML.Common/OwmlConfig.cs
@@ -17,6 +17,9 @@ namespace OWML.Common
 		[JsonProperty("incrementalGC")]
 		public bool IncrementalGC { get; set; }
 
+		[JsonProperty("prepatchersExecuted")] 
+		public string[] PrepatchersExecuted { get; set; }
+
 		[JsonIgnore]
 		public bool IsSpaced => Directory.Exists(Path.Combine(GamePath, "Outer Wilds_Data"));
 

--- a/src/OWML.Launcher/App.cs
+++ b/src/OWML.Launcher/App.cs
@@ -139,7 +139,8 @@ namespace OWML.Launcher
 			return mods
 				.Where(ShouldExecutePatcher)
 				.Where(mod => !ExecutePatcher(mod))
-				.Select(mod => mod.Manifest.UniqueName).ToList();
+				.Select(mod => mod.Manifest.UniqueName)
+				.ToList();
 		}
 
 		private static bool ShouldExecutePatcher(IModData modData) =>
@@ -158,12 +159,12 @@ namespace OWML.Launcher
 			return mods
 				.Where(modData => !string.IsNullOrEmpty(modData.Manifest.Unpatcher) && !modData.Enabled &&
 				                  needUnpatch.Contains(modData.Manifest.UniqueName))
-				.ToList()
-				.Where(UnpatchMod)
-				.Select(modData => modData.Manifest.UniqueName).ToArray();
+				.Where(ExecuteUnpatcher)
+				.Select(modData => modData.Manifest.UniqueName)
+				.ToArray();
 		}
 		
-		private bool UnpatchMod(IModData modData)
+		private bool ExecuteUnpatcher(IModData modData)
 		{
 			_writer.WriteLine($"Executing patcher for {modData.Manifest.UniqueName} v{modData.Manifest.Version}", MessageType.Message);
 

--- a/src/OWML.Launcher/App.cs
+++ b/src/OWML.Launcher/App.cs
@@ -138,7 +138,6 @@ namespace OWML.Launcher
 			_writer.WriteLine("Executing patchers...", MessageType.Debug);
 			return mods
 				.Where(ShouldExecutePatcher)
-				.ToList()
 				.Where(mod => !ExecutePatcher(mod))
 				.Select(mod => mod.Manifest.UniqueName).ToList();
 		}


### PR DESCRIPTION
Adds the ability for mods to specify an `unpatcher`.

This allows mods that use prepatchers to undo what those prepatchers did once disabled. Meaning users won't need to verify game files or undo changes manually.

## Added

- New manifest field: `unpatcher`
- New OWML config field: `prepatchersExecuted`
- New docs page on prepatching
- Manager now hides prepatcher warnings for mods with unpatchers on disable
