### PR TITLE
Multipart Mod Proposal

### DIFF
--- a/schemas/manifest_schema.json
+++ b/schemas/manifest_schema.json
@@ -129,6 +129,13 @@
                 ]
             }
         },
+        "additionalAssets": {
+            "type": "array",
+            "description": "A list of additonal *ZIP* files the manager should download from the GitHub release of this mod and extract at the root of the mod folder. Use this when you need to bypass the 2 GB limit on GitHub releases",
+            "items": {
+                "type": "string"
+            }
+        },
         "pathsToPreserve": {
             "type": "array",
             "description": "The paths to preserve when updating the mod\nAutomatically includes config.json, manifest.json, and save.json",


### PR DESCRIPTION
Due to the advent of larger mods in development, we'll eventually need to deal with mods that are too large for 2 GB release asset limit. After talking on the Discord our current idea is a new field in the manifest that tells the manager to download additional ZIP files by name from the release of the mod (simple enough to just get the parent of the `downloadUrl` from the db and append the name to that). The manager would then extract these zip on top of the current mod's folder, effectively combining them all.