### PR TITLE
Updated file logging

### DIFF
--- a/src/OWML.Common/Interfaces/IOwmlConfig.cs
+++ b/src/OWML.Common/Interfaces/IOwmlConfig.cs
@@ -1,4 +1,6 @@
-﻿namespace OWML.Common
+﻿using System;
+
+namespace OWML.Common
 {
 	public interface IOwmlConfig
 	{
@@ -25,5 +27,7 @@
 		bool IncrementalGC { get; set; }
 
 		int SocketPort { get; set; }
+
+		DateTime LoadTime { get; set; }
 	}
 }

--- a/src/OWML.Common/OwmlConfig.cs
+++ b/src/OWML.Common/OwmlConfig.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using Newtonsoft.Json;
 
 namespace OWML.Common
@@ -16,6 +17,9 @@ namespace OWML.Common
 
 		[JsonProperty("incrementalGC")]
 		public bool IncrementalGC { get; set; }
+
+		[JsonProperty("loadTime")]
+		public DateTime LoadTime { get; set; }
 
 		[JsonIgnore]
 		public bool IsSpaced => Directory.Exists(Path.Combine(GamePath, "Outer Wilds_Data"));

--- a/src/OWML.Launcher/OWML.Manifest.json
+++ b/src/OWML.Launcher/OWML.Manifest.json
@@ -3,7 +3,7 @@
   "author": "Alek",
   "name": "OWML",
   "uniqueName": "Alek.OWML",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "minGameVersion": "1.1.15.1018",
   "maxGameVersion": "1.1.15.1018"
 }

--- a/src/OWML.Launcher/Program.cs
+++ b/src/OWML.Launcher/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using OWML.Abstractions;
 using OWML.Common;
 using OWML.GameFinder;
@@ -25,6 +26,7 @@ namespace OWML.Launcher
 			var hasConsolePort = argumentHelper.HasArgument(Constants.ConsolePortArgument);
 			SaveConsolePort(owmlConfig, hasConsolePort, argumentHelper);
 			SaveOwmlPath(owmlConfig);
+			SaveCurrentLogPath(owmlConfig);
 			var owmlManifest = GetOwmlManifest();
 			var consoleWriter = CreateConsoleWriter(owmlConfig, owmlManifest, hasConsolePort);
 
@@ -76,6 +78,17 @@ namespace OWML.Launcher
 		private static void SaveOwmlPath(IOwmlConfig owmlConfig)
 		{
 			owmlConfig.OWMLPath = AppDomain.CurrentDomain.BaseDirectory;
+			JsonHelper.SaveJsonObject(Constants.OwmlConfigFileName, owmlConfig);
+		}
+
+		private static void SaveCurrentLogPath(IOwmlConfig owmlConfig)
+		{
+			if (File.Exists($"{owmlConfig.LogsPath}/latest.txt"))
+			{
+				File.Delete($"{owmlConfig.LogsPath}/latest.txt");
+			}
+
+			owmlConfig.LoadTime = DateTime.Now;
 			JsonHelper.SaveJsonObject(Constants.OwmlConfigFileName, owmlConfig);
 		}
 

--- a/src/OWML.Logging/ModLogger.cs
+++ b/src/OWML.Logging/ModLogger.cs
@@ -21,8 +21,8 @@ namespace OWML.Logging
 				Directory.CreateDirectory(config.LogsPath);
 			}
 
-			_logFileName = $"{config.LogsPath}/latest.txt";
-			File.Delete(_logFileName);
+			_latestFileName = $"{config.LogsPath}/latest.txt";
+			File.Delete(_latestFileName);
 		}
 
 		[Obsolete("Use ModHelper.Console.WriteLine with messageType = Debug instead.")]

--- a/src/OWML.Logging/ModLogger.cs
+++ b/src/OWML.Logging/ModLogger.cs
@@ -35,8 +35,15 @@ namespace OWML.Logging
 		private static void LogInternal(string message)
 		{
 			var text = $"{DateTime.Now}: {message}{Environment.NewLine}";
-			File.AppendAllText(_logFileName, text);
-			File.AppendAllText(_latestFileName, text);
+			try
+			{
+				File.AppendAllText(_logFileName, text);
+				File.AppendAllText(_latestFileName, text);
+			}
+			catch
+			{
+				// ignored
+			}
 		}
 	}
 }

--- a/src/OWML.Logging/ModLogger.cs
+++ b/src/OWML.Logging/ModLogger.cs
@@ -14,7 +14,7 @@ namespace OWML.Logging
 		public ModLogger(IOwmlConfig config, IModManifest manifest)
 		{
 			_manifest = manifest;
-			_logFileName = $"{config.LogsPath}/OWML.Log.{DateTime.Now:yyyy-MM-ddTHH:mm:ss}.txt";
+			_logFileName = $"{config.LogsPath}/OWML.Log.{config.LoadTime:yyyy-MM-ddTHH.mm.ss}.txt";
 
 			if (!Directory.Exists(config.LogsPath))
 			{
@@ -22,7 +22,6 @@ namespace OWML.Logging
 			}
 
 			_latestFileName = $"{config.LogsPath}/latest.txt";
-			File.Delete(_latestFileName);
 		}
 
 		[Obsolete("Use ModHelper.Console.WriteLine with messageType = Debug instead.")]

--- a/src/OWML.Logging/ModLogger.cs
+++ b/src/OWML.Logging/ModLogger.cs
@@ -9,16 +9,20 @@ namespace OWML.Logging
 	{
 		private readonly IModManifest _manifest;
 		private static string _logFileName;
+		private static string _latestFileName;
 
 		public ModLogger(IOwmlConfig config, IModManifest manifest)
 		{
 			_manifest = manifest;
-			_logFileName = $"{config.LogsPath}/OWML.Log.{DateTime.Now:dd-MM-yyyy-HH.mm.ss}.txt";
+			_logFileName = $"{config.LogsPath}/OWML.Log.{DateTime.Now:yyyy-MM-ddTHH:mm:ss}.txt";
 
 			if (!Directory.Exists(config.LogsPath))
 			{
 				Directory.CreateDirectory(config.LogsPath);
 			}
+
+			_logFileName = $"{config.LogsPath}/latest.txt";
+			File.Delete(_logFileName);
 		}
 
 		[Obsolete("Use ModHelper.Console.WriteLine with messageType = Debug instead.")]
@@ -29,7 +33,11 @@ namespace OWML.Logging
 		public void Log(params object[] objects) =>
 			Log(string.Join(" ", objects.Select(o => o.ToString()).ToArray()));
 
-		private static void LogInternal(string message) =>
-			File.AppendAllText(_logFileName, $"{DateTime.Now}: {message}{Environment.NewLine}");
+		private static void LogInternal(string message)
+		{
+			var text = $"{DateTime.Now}: {message}{Environment.NewLine}";
+			File.AppendAllText(_logFileName, text);
+			File.AppendAllText(_latestFileName, text);
+		}
 	}
 }

--- a/src/OWML.ModHelper.Events/HarmonyHelper.cs
+++ b/src/OWML.ModHelper.Events/HarmonyHelper.cs
@@ -33,7 +33,7 @@ namespace OWML.ModHelper.Events
 				if (_owmlConfig.DebugMode)
 				{
 					_console.WriteLine("Enabling Harmony debug mode.", MessageType.Debug);
-					FileLog.logPath = $"{_owmlConfig.LogsPath}/Harmony.Log.{DateTime.Now:dd-MM-yyyy-HH.mm.ss}.txt";
+					FileLog.logPath = $"{_owmlConfig.LogsPath}/Harmony.Log.{DateTime.Now:yyyy-MM-ddTHH:mm:ss}.txt";
 					HarmonyFileLog.Enabled = true;
 				}
 				harmony = new Harmony(_manifest.UniqueName);

--- a/src/OWML.ModHelper.Events/HarmonyHelper.cs
+++ b/src/OWML.ModHelper.Events/HarmonyHelper.cs
@@ -33,7 +33,7 @@ namespace OWML.ModHelper.Events
 				if (_owmlConfig.DebugMode)
 				{
 					_console.WriteLine("Enabling Harmony debug mode.", MessageType.Debug);
-					FileLog.logPath = $"{_owmlConfig.LogsPath}/Harmony.Log.{DateTime.Now:yyyy-MM-ddTHH:mm:ss}.txt";
+					FileLog.logPath = $"{_owmlConfig.LogsPath}/Harmony.Log.{_owmlConfig.LoadTime:yyyy-MM-ddTHH.mm.ss}.txt";
 					HarmonyFileLog.Enabled = true;
 				}
 				harmony = new Harmony(_manifest.UniqueName);


### PR DESCRIPTION
- Added `LoadTime` to OWML config.
- Written log files are now based on the ISO 8601 standard (`OWML.Log.YYYY-MM-DDThh:mm:ss.txt`).
   - This applies to normal log files and Harmony log files.
- Added `latest.txt`. Contains the same data as the newest log file, but is overwritten on OWML load.