### PR TITLE
Translate selector's options

### DIFF
--- a/src/OWML.ModHelper.Menus/NewMenuSystem/MenuManager.cs
+++ b/src/OWML.ModHelper.Menus/NewMenuSystem/MenuManager.cs
@@ -289,13 +289,13 @@ namespace OWML.ModHelper.Menus.NewMenuSystem
 								break;
 							case SettingType.SELECTOR:
 								var currentSelectorValue = mod.ModHelper.Config.GetSettingsValue<string>(name);
-								var options = settingObject["options"].ToArray().Select(x => mod.ModHelper.MenuTranslations.GetLocalizedString(x.ToString())).ToArray();
+								var options = settingObject["options"].ToArray().Select(x => x.ToString()).ToArray();
 								var currentSelectedIndex = Array.IndexOf(options, currentSelectorValue);
-								var settingSelector = OptionsMenuManager.AddSelectorInput(newModTab, label, options, tooltip, true, currentSelectedIndex);
+								var settingSelector = OptionsMenuManager.AddSelectorInput(newModTab, label, options.Select(x => mod.ModHelper.MenuTranslations.GetLocalizedString(x)).ToArray(), tooltip, true, currentSelectedIndex);
 								settingSelector.ModSettingKey = name;
 								settingSelector.OnValueChanged += (int newIndex, string newSelection) =>
 								{
-									mod.ModHelper.Config.SetSettingsValue(name, newSelection);
+									mod.ModHelper.Config.SetSettingsValue(name, options[newIndex]);
 									mod.ModHelper.Storage.Save(mod.ModHelper.Config, Constants.ModConfigFileName);
 									mod.Configure(mod.ModHelper.Config);
 								};

--- a/src/OWML.ModHelper.Menus/NewMenuSystem/MenuManager.cs
+++ b/src/OWML.ModHelper.Menus/NewMenuSystem/MenuManager.cs
@@ -289,7 +289,7 @@ namespace OWML.ModHelper.Menus.NewMenuSystem
 								break;
 							case SettingType.SELECTOR:
 								var currentSelectorValue = mod.ModHelper.Config.GetSettingsValue<string>(name);
-								var options = settingObject["options"].ToArray().Select(x => x.ToString()).ToArray();
+								var options = settingObject["options"].ToArray().Select(x => mod.ModHelper.MenuTranslations.GetLocalizedString(x.ToString())).ToArray();
 								var currentSelectedIndex = Array.IndexOf(options, currentSelectorValue);
 								var settingSelector = OptionsMenuManager.AddSelectorInput(newModTab, label, options, tooltip, true, currentSelectedIndex);
 								settingSelector.ModSettingKey = name;


### PR DESCRIPTION
Make MenuManager able to get localized text for selector's options:
- Displayed option array go through `GetLocalizedString`
- `OnValueChanged` cannot set `newSelection` _(localized)_ directly anymore, so it sets `options[newIndex]` _(not localized)_ instead