### PR TITLE
Fix "Default Settings" button for text/numeric settings

### DIFF
--- a/src/OWML.ModHelper.Menus/NewMenuSystem/OptionsMenuManager.cs
+++ b/src/OWML.ModHelper.Menus/NewMenuSystem/OptionsMenuManager.cs
@@ -710,6 +710,8 @@ namespace OWML.ModHelper.Menus.NewMenuSystem
 			textEntry.RegisterPopup(textInputPopup);
 			textEntry.IsNumeric = isNumeric;
 
+			menu._menuOptions = menu._menuOptions.Add(textEntry);
+
 			textEntry.OnConfirmEntry += () =>
 			{
 				_menuManager.ForceModOptionsOpen(false);


### PR DESCRIPTION
Resolves an issue where the "Default Settings" button in a mod setting menu does not reset text/numeric settings because `IOWMLTextEntryElement`s are never added to `_menuOptions`.