### PR TITLE
2.16.3

### DIFF
--- a/src/OWML.Launcher/OWML.Manifest.json
+++ b/src/OWML.Launcher/OWML.Manifest.json
@@ -3,7 +3,7 @@
   "author": "Alek",
   "name": "OWML",
   "uniqueName": "Alek.OWML",
-  "version": "2.16.2",
+  "version": "2.16.3",
   "minGameVersion": "1.1.15.1018",
   "maxGameVersion": "1.1.16.1388"
 }

--- a/src/OWML.ModHelper.Menus/NewMenuSystem/MenuUtilities.cs
+++ b/src/OWML.ModHelper.Menus/NewMenuSystem/MenuUtilities.cs
@@ -1,0 +1,28 @@
+﻿using System.Linq;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace OWML.ModHelper.Menus.NewMenuSystem
+{
+	internal static class MenuUtilities
+	{
+		internal static void AddToLangController(Text textComponent)
+		{
+			var controllers = Resources.FindObjectsOfTypeAll<FontAndLanguageController>();
+
+			if (controllers.Length == 0)
+			{
+				return;
+			}
+
+			var controller = controllers.FirstOrDefault(x => x.isActiveAndEnabled);
+
+			if (controller == null)
+			{
+				return;
+			}
+
+			controller.AddTextElement(textComponent, false);
+		}
+	}
+}

--- a/src/OWML.ModHelper.Menus/NewMenuSystem/OptionsMenuManager.cs
+++ b/src/OWML.ModHelper.Menus/NewMenuSystem/OptionsMenuManager.cs
@@ -185,7 +185,10 @@ namespace OWML.ModHelper.Menus.NewMenuSystem
 			newSubMenuTabButton.transform.SetSiblingIndex(newSubMenuTabButton.transform.parent.childCount - 3);
 			newSubMenuTabButton.name = $"Button-{name}Tab";
 			Object.Destroy(newSubMenuTabButton.GetComponentInChildren<LocalizedText>());
-			newSubMenuTabButton.GetComponentInChildren<Text>().text = name;
+
+			var text = newSubMenuTabButton.GetComponentInChildren<Text>();
+			text.text = name;
+			MenuUtilities.AddToLangController(text);
 
 			var newSubMenu = Object.Instantiate(existingSubMenu, menu.transform);
 			newSubMenu.transform.localScale = Vector3.one;
@@ -282,6 +285,9 @@ namespace OWML.ModHelper.Menus.NewMenuSystem
 			labelBlock.minWidth = 860;
 			labelBlock.preferredWidth = -1;
 
+			MenuUtilities.AddToLangController(customCheckboxScript._label);
+			MenuUtilities.AddToLangController(customCheckboxScript._displayText);
+
 			return customCheckboxScript;
 		}
 
@@ -334,6 +340,10 @@ namespace OWML.ModHelper.Menus.NewMenuSystem
 			labelBlock.minWidth = 860;
 			labelBlock.preferredWidth = -1;
 
+			MenuUtilities.AddToLangController(newScript._label);
+			MenuUtilities.AddToLangController(newScript.ButtonTrue.GetComponent<UIStyleApplier>()._textItems[0]);
+			MenuUtilities.AddToLangController(newScript.ButtonFalse.GetComponent<UIStyleApplier>()._textItems[0]);
+
 			return newScript;
 		}
 
@@ -381,6 +391,9 @@ namespace OWML.ModHelper.Menus.NewMenuSystem
 			labelBlock.minWidth = 860;
 			labelBlock.preferredWidth = -1;
 
+			MenuUtilities.AddToLangController(newScript._label);
+			MenuUtilities.AddToLangController(newScript._displayText);
+
 			return newScript;
 		}
 
@@ -418,6 +431,8 @@ namespace OWML.ModHelper.Menus.NewMenuSystem
 			var labelBlock = newScript.transform.Find("HorizontalLayoutGroup").Find("Panel-Label").GetComponent<LayoutElement>();
 			labelBlock.minWidth = 860;
 			labelBlock.preferredWidth = -1;
+
+			MenuUtilities.AddToLangController(newScript._label);
 
 			return newScript;
 		}
@@ -567,6 +582,8 @@ namespace OWML.ModHelper.Menus.NewMenuSystem
 				menu._selectOnActivate = newButtonObj.GetComponent<Selectable>();
 			}
 
+			MenuUtilities.AddToLangController(menuOption._label);
+
 			return submitAction;
 		}
 
@@ -692,6 +709,9 @@ namespace OWML.ModHelper.Menus.NewMenuSystem
 				menu._selectOnActivate = newButtonObj.GetComponent<Button>();
 			}
 
+			MenuUtilities.AddToLangController(menuOption._label);
+			MenuUtilities.AddToLangController(labelComponent);
+
 			return submitAction;
 		}
 
@@ -777,6 +797,8 @@ namespace OWML.ModHelper.Menus.NewMenuSystem
 			newObj.transform.localScale = Vector3.one;
 			newObj.transform.localPosition = Vector3.zero;
 			newObj.transform.localRotation = Quaternion.identity;
+
+			MenuUtilities.AddToLangController(text);
 		}
 
 		public KeyRebindingElement CreateRebinding(Menu menu, string label, string tooltip, RebindableID id)
@@ -821,6 +843,8 @@ namespace OWML.ModHelper.Menus.NewMenuSystem
 			controlBlock.flexibleWidth = 1;
 			controlBlock.preferredWidth = -1;
 
+			MenuUtilities.AddToLangController(text);
+
 			return rebindingElement;
 		}
 
@@ -844,6 +868,8 @@ namespace OWML.ModHelper.Menus.NewMenuSystem
 
 			var tabButton = newButton.GetComponent<TabButton>();
 			tabButton._tabbedMenu = menu ?? throw new System.Exception("Menu cannot be null.");
+
+			MenuUtilities.AddToLangController(text);
 
 			return tabButton;
 		}

--- a/src/OWML.ModHelper.Menus/NewMenuSystem/OptionsMenuManager.cs
+++ b/src/OWML.ModHelper.Menus/NewMenuSystem/OptionsMenuManager.cs
@@ -710,6 +710,8 @@ namespace OWML.ModHelper.Menus.NewMenuSystem
 			textEntry.RegisterPopup(textInputPopup);
 			textEntry.IsNumeric = isNumeric;
 
+			menu._menuOptions = menu._menuOptions.Add(textEntry);
+
 			textEntry.OnConfirmEntry += () =>
 			{
 				_menuManager.ForceModOptionsOpen(false);

--- a/src/OWML.ModHelper.Menus/NewMenuSystem/Patches.cs
+++ b/src/OWML.ModHelper.Menus/NewMenuSystem/Patches.cs
@@ -5,12 +5,9 @@ using OWML.ModHelper.Input;
 using OWML.ModHelper.Menus.CustomInputs;
 using OWML.Utils;
 using System;
-using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Reflection;
 using UnityEngine;
-using UnityEngine.InputSystem;
 using UnityEngine.UI;
 
 namespace OWML.ModHelper.Menus.NewMenuSystem
@@ -282,6 +279,15 @@ namespace OWML.ModHelper.Menus.NewMenuSystem
 			Menu_Deactivate_Stub(__instance, keepPreviousMenuVisible);
 			Locator.GetMenuInputModule().OnInputModuleTab -= __instance.OnInputModuleTabEvent;
 			return false;
+		}
+
+		[HarmonyPrefix]
+		[HarmonyPatch(typeof(FontAndLanguageController), nameof(FontAndLanguageController.InitializeFont))]
+		private static bool FontAndLanguageController_InitializeFont(FontAndLanguageController __instance)
+		{
+			// Remove null entries (eg where popup menus have been destroyed)
+			__instance._textContainerList = __instance._textContainerList.Where(x => x.textElement != null).ToList();
+			return true;
 		}
 	}
 }

--- a/src/OWML.ModHelper.Menus/NewMenuSystem/PauseMenuManager.cs
+++ b/src/OWML.ModHelper.Menus/NewMenuSystem/PauseMenuManager.cs
@@ -11,7 +11,6 @@ namespace OWML.ModHelper.Menus.NewMenuSystem
 	public class PauseMenuManager : IPauseMenuManager
 	{
 		private IModConsole _console;
-		private FontAndLanguageController _languageController;
 		private GameObject _pauseMenuItemsTemplate;
 		private GameObject _buttonPrefab;
 
@@ -45,16 +44,6 @@ namespace OWML.ModHelper.Menus.NewMenuSystem
 					}
 				};
 			}
-		}
-
-		private void AddToLangController(Text textComponent)
-		{
-			if (_languageController == null)
-			{
-				_languageController = Resources.FindObjectsOfTypeAll<global::PauseMenuManager>()[0].transform.GetChild(0).GetComponent<FontAndLanguageController>();
-			}
-
-			_languageController.AddTextElement(textComponent, false);
 		}
 
 		private void MakePauseMenuItemsTemplate()
@@ -122,7 +111,7 @@ namespace OWML.ModHelper.Menus.NewMenuSystem
 
 			SetButtonText(submitAction, name);
 			SetButtonIndex(submitAction, index, fromTop);
-			AddToLangController(submitAction.GetComponentInChildren<Text>());
+			MenuUtilities.AddToLangController(submitAction.GetComponentInChildren<Text>());
 
 			return submitAction;
 		}
@@ -142,7 +131,7 @@ namespace OWML.ModHelper.Menus.NewMenuSystem
 
 			SetButtonText(submitActionMenu, name);
 			SetButtonIndex(submitActionMenu, index, fromTop);
-			AddToLangController(submitActionMenu.GetComponentInChildren<Text>());
+			MenuUtilities.AddToLangController(submitActionMenu.GetComponentInChildren<Text>());
 
 			menuRootObject.SetActive(true);
 			return submitActionMenu;

--- a/src/OWML.ModHelper.Menus/NewMenuSystem/PopupMenuManager.cs
+++ b/src/OWML.ModHelper.Menus/NewMenuSystem/PopupMenuManager.cs
@@ -100,6 +100,11 @@ namespace OWML.ModHelper.Menus.NewMenuSystem
 				new ScreenPrompt(InputLibrary.cancel, cancelText),
 				true,
 				true);
+
+			MenuUtilities.AddToLangController(popup._labelText);
+			MenuUtilities.AddToLangController(popup._confirmButton._buttonText);
+			MenuUtilities.AddToLangController(popup._cancelButton._buttonText);
+
 			return popup;
 		}
 
@@ -123,6 +128,10 @@ namespace OWML.ModHelper.Menus.NewMenuSystem
 				null,
 				true,
 				false);
+
+			MenuUtilities.AddToLangController(popup._labelText);
+			MenuUtilities.AddToLangController(popup._confirmButton._buttonText);
+
 			return popup;
 		}
 
@@ -168,6 +177,12 @@ namespace OWML.ModHelper.Menus.NewMenuSystem
 				new ScreenPrompt(InputLibrary.menuConfirm, confirm1Text),
 				new ScreenPrompt(InputLibrary.confirm2, confirm2Text),
 				new ScreenPrompt(InputLibrary.cancel, cancelText));
+
+			MenuUtilities.AddToLangController(popup._labelText);
+			MenuUtilities.AddToLangController(popup._confirmButton1._buttonText);
+			MenuUtilities.AddToLangController(popup._confirmButton2._buttonText);
+			MenuUtilities.AddToLangController(popup._cancelButton._buttonText);
+
 			return popup;
 		}
 
@@ -225,6 +240,10 @@ namespace OWML.ModHelper.Menus.NewMenuSystem
 				popup.SetInputFieldPlaceholderText(placeholderMessage);
 			};
 
+			MenuUtilities.AddToLangController(popup._labelText);
+			MenuUtilities.AddToLangController(popup._confirmButton._buttonText);
+			MenuUtilities.AddToLangController(popup._cancelButton._buttonText);
+
 			return popup;
 		}
 
@@ -279,6 +298,13 @@ namespace OWML.ModHelper.Menus.NewMenuSystem
 				new ScreenPrompt(InputLibrary.confirm2, confirm2Text),
 				new ScreenPrompt(InputLibrary.signalscope, confirm3Text),
 				new ScreenPrompt(InputLibrary.cancel, cancelText));
+
+			MenuUtilities.AddToLangController(popup._labelText);
+			MenuUtilities.AddToLangController(popup._confirmButton1._buttonText);
+			MenuUtilities.AddToLangController(popup._confirmButton2._buttonText);
+			MenuUtilities.AddToLangController(popup._confirmButton3._buttonText);
+			MenuUtilities.AddToLangController(popup._cancelButton._buttonText);
+
 			return popup;
 		}
 	}

--- a/src/SampleMods/OWML.EnableDebugMode/manifest.json
+++ b/src/SampleMods/OWML.EnableDebugMode/manifest.json
@@ -5,6 +5,6 @@
 	"name": "EnableDebugMode",
 	"uniqueName": "Alek.EnableDebugMode",
 	"version": "0.3.0",
-	"owmlVersion": "2.16.0",
+	"owmlVersion": "2.16.3",
 	"description": "Enables the debug mode in Outer Wilds"
 }

--- a/src/SampleMods/OWML.EnumExample/manifest.json
+++ b/src/SampleMods/OWML.EnumExample/manifest.json
@@ -5,6 +5,6 @@
 	"name": "Enum Example",
 	"uniqueName": "MegaPiggy.EnumExample",
 	"version": "1.0.0",
-	"owmlVersion": "2.16.0",
+	"owmlVersion": "2.16.3",
 	"description": "Example for testing enum creator"
 }

--- a/src/SampleMods/OWML.ExampleAPI/manifest.json
+++ b/src/SampleMods/OWML.ExampleAPI/manifest.json
@@ -5,6 +5,6 @@
 	"name": "ExampleAPI",
 	"uniqueName": "_nebula.ExampleAPI",
 	"version": "0.3.0",
-	"owmlVersion": "2.16.0",
+	"owmlVersion": "2.16.3",
 	"description": "Example API for testing OWML.Interaction"
 }

--- a/src/SampleMods/OWML.LoadCustomAssets/manifest.json
+++ b/src/SampleMods/OWML.LoadCustomAssets/manifest.json
@@ -5,7 +5,7 @@
 	"name": "LoadCustomAssets",
 	"uniqueName": "Alek.LoadCustomAssets",
 	"version": "0.7.0",
-	"owmlVersion": "2.16.0",
+	"owmlVersion": "2.16.3",
 	"description": "A mod for testing loading of custom assets",
 	"dependencies": [
 		"_nebula.ExampleAPI"

--- a/src/SampleMods/OWML.MenuExample/manifest.json
+++ b/src/SampleMods/OWML.MenuExample/manifest.json
@@ -5,6 +5,6 @@
   "name": "MenuExample",
   "uniqueName": "_nebula.MenuExample",
   "version": "1.0.0",
-  "owmlVersion": "2.16.0",
+  "owmlVersion": "2.16.3",
   "description": "Example menus for the OWML menu system"
 }


### PR DESCRIPTION
- Fixed text entry inputs not being affected by the Default Settings button. (Thanks @milliero-se!)
- Adds everything to a `FontAndLanguageController` - should fix missing text when playing in non-latin languages. (#573)